### PR TITLE
Fix transfer results scalability (fixes #15)

### DIFF
--- a/cfg/auth.py
+++ b/cfg/auth.py
@@ -114,7 +114,9 @@ class mysqlDB(object):
             database=dbname,
             user=user,
             password=password,
-            host=host)
+            host=host,
+            # we need to enable this to upload files to mysql
+            local_infile=True)
 
     def query(self, query, data):
         self._db_cur = self._db_connection.cursor()
@@ -160,7 +162,9 @@ class dev_mysqlDB(object):
             database=dbname,
             user=user,
             password=password,
-            host=host)
+            host=host,
+            # we need to enable this to upload files to mysql
+            local_infile=True)
 
     def query(self, query, data):
         self._db_cur = self._db_connection.cursor()

--- a/transfer_results_module/transfer_results.py
+++ b/transfer_results_module/transfer_results.py
@@ -73,6 +73,8 @@ def delete_firebase_results(all_results):
             data[task_id][child_id] = None
             q.put([fb_db, task_id, child_id])
 
+        print(data[task_id])
+
     for i in range(num_threads):
         worker = threading.Thread(
             target=delete_result_in_firebase,

--- a/transfer_results_module/transfer_results.py
+++ b/transfer_results_module/transfer_results.py
@@ -191,7 +191,7 @@ def run_transfer_results():
         # start to import the old results first
         with open(results_filename) as results_file:
             results = json.load(results_file)
-            results_txt_filename, number_of_results = results_to_txt(results)
+            results_txt_filename = results_to_txt(results)
             logging.warning("there are results in %s that we didnt't insert. do it now!" % results_filename)
             save_results_mysql(results_txt_filename)
 

--- a/transfer_results_module/transfer_results.py
+++ b/transfer_results_module/transfer_results.py
@@ -43,13 +43,15 @@ def delete_firebase_results(all_results):
 
     # we will use multilocation update to delete the entries, therefore we crate an dict with the items we want to delete
     data = {
-        'results': {}
     }
 
     for task_id, results in all_results.items():
-        data['results'][task_id] = {}
         for child_id, result in results.items():
-            data['results'][task_id][child_id] = None
+            key = 'results/{task_id}/{child_id}'.format(
+                task_id=task_id,
+                child_id=child_id)
+
+            data[key] = None
             #q.put([fb_db, task_id, child_id])
 
 

--- a/transfer_results_module/transfer_results.py
+++ b/transfer_results_module/transfer_results.py
@@ -14,10 +14,10 @@ import logging
 import json
 import os
 import time
+import csv
 import requests
 from auth import firebase_admin_auth
 from auth import mysqlDB
-from send_slack_message import send_slack_message
 
 import argparse
 
@@ -64,26 +64,28 @@ def delete_firebase_results(all_results):
 
 def results_to_txt(all_results):
     results_txt_filename = 'raw_results.txt'
-    results_txt_file = open(results_txt_filename, 'w')
+    # If csvfile is a file object, it should be opened with newline=''
+    results_txt_file = open(results_txt_filename, 'w', newline='')
+    csvwriter = csv.writer(results_txt_file, delimiter='\t')
 
     number_of_results = 0
     for task_id, results in all_results.items():
         for child_id, result in results.items():
             number_of_results += 1
-            outline = '{task_id}\t{user_id}\t{project_id}\t{timestamp}\t{result}\t{wkt}\t{task_x}\t{task_y}\t{task_z}\t{duplicates}\n'.format(
-                task_id = task_id,
-                user_id = result['data']['user'],
-                project_id = result['data']['projectId'],
-                result = result['data']['result'],
-                timestamp = result['data']['timestamp'],
-                wkt = result['data']['wkt'],
-                task_x = task_id.split('-')[1],
-                task_y = task_id.split('-')[2],
-                task_z = task_id.split('-')[0],
-                duplicates = 0
-            )
 
-            results_txt_file.write(outline)
+            output_list = [
+                task_id,
+                result['data']['user'],
+                int(result['data']['projectId']),
+                int(result['data']['timestamp']),
+                int(result['data']['result']),
+                result['data']['wkt'],
+                task_id.split('-')[1],
+                task_id.split('-')[2],
+                task_id.split('-')[0],
+                0
+            ]
+            csvwriter.writerow(output_list)
 
     results_txt_file.close()
     logging.warning('there are %s results to import' % number_of_results)

--- a/transfer_results_module/transfer_results.py
+++ b/transfer_results_module/transfer_results.py
@@ -75,8 +75,6 @@ def delete_firebase_results(all_results):
             data['results'][task_id][child_id] = None
             #q.put([fb_db, task_id, child_id])
 
-        print(data[task_id])
-
     print('start deleting/ update with None')
     fb_db.update(data)
     print('finished deleting results')

--- a/transfer_results_module/transfer_results.py
+++ b/transfer_results_module/transfer_results.py
@@ -48,6 +48,7 @@ def delete_result_in_firebase(q):
         fb_db, task_id, child_id = q.get()
         try:
             fb_db.child("results").child(task_id).child(child_id).remove()
+            print('deleted entry: %s, %s' % (task_id, child_id))
         except:
             # add a catch, if something with the connection to firebase goes wrong and log potential errors
             tb = sys.exc_info()
@@ -64,8 +65,12 @@ def delete_firebase_results(all_results):
     q = Queue(maxsize=0)
     num_threads = 24
 
+    data = {}
+
     for task_id, results in all_results.items():
+        data[task_id] = {}
         for child_id, result in results.items():
+            data[task_id][child_id] = None
             q.put([fb_db, task_id, child_id])
 
     for i in range(num_threads):

--- a/transfer_results_module/transfer_results.py
+++ b/transfer_results_module/transfer_results.py
@@ -54,6 +54,8 @@ def delete_firebase_results(all_results):
 
 
     print('start deleting/ update with None')
+    print(data)
+    fb_db.child('results').child('test').set('this is a test')
     fb_db.update(data)
     print('finished deleting results')
     logging.warning('deleted results in firebase')

--- a/transfer_results_module/transfer_results.py
+++ b/transfer_results_module/transfer_results.py
@@ -54,10 +54,6 @@ def delete_firebase_results(all_results):
             data[key] = None
             #q.put([fb_db, task_id, child_id])
 
-
-    print('start deleting/ update with None')
-    print(data)
-    fb_db.child('results').child('test').set('this is a test')
     fb_db.update(data)
     print('finished deleting results')
     logging.warning('deleted results in firebase')

--- a/transfer_results_module/transfer_results.py
+++ b/transfer_results_module/transfer_results.py
@@ -44,8 +44,7 @@ def delete_firebase_results(all_results):
     fb_db = firebase.database()
 
     # we will use multilocation update to delete the entries, therefore we crate an dict with the items we want to delete
-    data = {
-    }
+    data = {}
 
     for task_id, results in all_results.items():
         for child_id, result in results.items():
@@ -96,10 +95,14 @@ def results_to_txt(all_results):
 def save_results_mysql(results_filename):
     ### this function saves the results from firebase to the mysql database
 
-    # first import to a table where we store the geom as text
+    # pre step delete table if exist
     m_con = mysqlDB()
+    sql_insert = 'DROP TABLE IF EXISTS raw_results CASCADE;'
+    m_con.query(sql_insert, None)
+    print('dropped raw results table')
+
+    # first import to a table where we store the geom as text
     sql_insert = '''
-        DROP TABLE IF EXISTS raw_results CASCADE;
         CREATE TABLE raw_results (
             task_id varchar(45) 
             ,user_id varchar(45) 
@@ -136,8 +139,6 @@ def save_results_mysql(results_filename):
           raw_results
         ON DUPLICATE KEY
           UPDATE results.duplicates = results.duplicates + 1
-        ;
-        DROP TABLE IF EXISTS raw_results CASCADE;
     '''
 
     m_con.query(sql_insert, None)

--- a/utils/error_handling.py
+++ b/utils/error_handling.py
@@ -1,0 +1,35 @@
+"""Error handling utils."""
+import sys
+import traceback
+
+import logging
+
+from send_slack_message import send_slack_message
+
+
+def _get_error_message_details(error):
+    """Nicely extract error text and traceback."""
+    error_traceback = sys.exc_info()[-1]
+    stk = traceback.extract_tb(error_traceback, 1)
+
+    return (
+        '{error_class} processing TIN / NPI message! '
+        'In {function}, the following error happened - {detail} at line {line}. '
+    ).format(
+        error_class=error.__class__.__name__,
+        function=stk[0][2],
+        detail=error.args[0],
+        line=stk[-1][1]
+    )
+
+
+def send_error(error, code_file):
+    """Send error message to logger and Slack."""
+    error_msg = _get_error_message_details(error)
+    logging.error(error_msg)
+    # send mail to mapswipe google group with
+    print(error_msg)
+    error_msg = _get_error_message_details(error)
+    head = 'google-mapswipe-workers: {}: error occured'.format(code_file)
+    send_slack_message(head + '\n' + error_msg)
+


### PR DESCRIPTION
This fixes an issue that occured during the last days.
Our old transfer results script was not able to import the results to mysql as quick as new data came into firebase. This was really critical and our server was using 100% all the time.

In the old script each result was transfered to mysql individually and afterwards deleted in firebase. This was not scalable.

In the new script the results from firebase are saved into a textfile. This textfile is first uploaded to an empty table in mysql ('raw_results'), afterwards we insert the items from the raw results table to the results table and check for duplicates.
Finally all entries are deleted in firebase using the "update" function. Removing items individually was not fast enough.