### PR TITLE
Run tests on Travis CI, a work in progress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+dist: xenial
+language: python
+python:
+  - "3.6"
+env:
+  CPLUS_INCLUDE_PATH=/usr/include/gdal
+  C_INCLUDE_PATH=/usr/include/gdal
+  MAPSWIPE_WORKER_LOG_DIR=/var/log/mapswipe_workers
+  MAPSWIPE_WORKER_DATA_DIR=/var/lib/mapswipe
+  MAPSWIPE_CONFIG_DIR=~/.config/mapswipe_workers
+  MAPSWIPE_DATA_DIR=/var/lib/mapswipe_workers/input_geometries
+before_install:
+# The version installed by default of libgdal is ancient
+# add the ubuntugis repo to update to a more recent version
+  - sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable -y
+  - sudo apt-get update -q
+  - sudo apt-get install libgdal-dev -y
+install:
+  - pip install -e .
+  - pip install gdal==`gdal-config --version`
+# command to run tests
+before_script:
+  - if [ ! -d "$MAPSWIPE_WORKER_DATA_DIR" ]; then sudo  mkdir -p $MAPSWIPE_WORKER_DATA_DIR; fi
+  - sudo chown $USER:$USER $MAPSWIPE_WORKER_DATA_DIR
+  - if [ ! -d "$MAPSWIPE_WORKER_LOG_DIR" ]; then sudo mkdir -p $MAPSWIPE_WORKER_LOG_DIR; fi
+  - if [ ! -f "$MAPSWIPE_WORKER_LOG_DIR/mapswipe_workers.log" ]; then sudo touch $MAPSWIPE_WORKER_LOG_DIR/mapswipe_workers.log; fi
+  - sudo chown $USER:$USER $MAPSWIPE_WORKER_LOG_DIR/mapswipe_workers.log
+  - if [ ! -d "$MAPSWIPE_CONFIG_DIR" ]; then sudo mkdir -p $MAPSWIPE_CONFIG_DIR; fi
+  - sudo cp config/ci-configuration.json $MAPSWIPE_CONFIG_DIR/configuration.json
+  - sudo chown $USER:$USER $MAPSWIPE_CONFIG_DIR/configuration.json
+  - if [ ! -d "$MAPSWIPE_DATA_DIR" ]; then sudo mkdir -p $MAPSWIPE_DATA_DIR; fi
+  - sudo chown $USER:$USER $MAPSWIPE_DATA_DIR
+  - npm install firebase-tools
+script:
+  - cd tests
+  - ./test_main.sh

--- a/config/ci-configuration.json
+++ b/config/ci-configuration.json
@@ -1,0 +1,38 @@
+{
+    "postgres": {
+        "database": "your_mapswipe_database",
+        "username": "your_mapswipe_db_username",
+        "password": "your_mapswipe_db_password",
+        "host": "localhost",
+        "port": "5432"
+    },
+    "firebase": {
+        "api_key": "your_firebase_api_key",
+        "auth_domain": "your_firebase_auth_domain",
+        "database_url": "your_firebase_database_url",
+        "storage_bucket": "your_firebase_storage_bucket",
+        "service_account": "serviceAccountKey.json"
+    },
+    "imagery":{
+        "bing": {
+            "api_key": "your_bing_api_key",
+            "url": "http://t0.tiles.virtualearth.net/tiles/a{quad_key}.jpeg?g=854&mkt=en-US&token={key}"
+        },
+        "digital_globe": {
+            "api_key": "your_digital_globe_api_key",
+            "url": "https://api.mapbox.com/v4/digitalglobe.nal0g75k/{z}/{x}/{y}.png?access_token={key}"
+        },
+        "sinergise": {
+            "api_key": "your_sinergise_api_key",
+            "url": "https://services.sentinel-hub.com/ogc/wmts/{key}?request=getTile&tilematrixset=PopularWebMercator256&tilematrix={z}&tilecol={x}&tilerow={y}&layer={layer}"
+        }
+    },
+    "slack": {
+        "token": "your_slack_token",
+        "channel": "your_slack_channel",
+        "username": "your_slack_username"
+    },
+    "import": {
+        "submission_key": "5G9Ce2J7"
+    }
+}


### PR DESCRIPTION
This does not work yet, but represents the progress I have been able to make so far on getting the tests in this repo to run on Travis CI. I am creating this pull request to record the progress I have been able to make, and help socialize/communicate the approach I am taking so I can receive feedback if I should do anything differently.

To get Travis CI to attempt to run the tests for this repo as specified by the .travis.yml file, see these instructions: https://docs.travis-ci.com/user/tutorial/#to-get-started-with-travis-ci
This must be done by someone who is a repo owner, but doesn't require too much more than connecting github to travis CI, and granting access to this repo.

I have been testing the .travis.yml file on a fork of this repo: https://github.com/vinaytota-optimizely/python-mapswipe-workers, and I've been able to get tests to run up to the following part:

```
2.76s$ ./test_main.sh
2019-06-21 22:12:44,450 - Mapswipe Workers - INFO - 5G9Ce2J7 - __init__ - start init
2019-06-21 22:12:44,457 - Mapswipe Workers - INFO - build_area_default_with_bing - validate geometry - input geometry is correct.
2019-06-21 22:12:44,458 - Mapswipe Workers - INFO - got geometry and extent from file
2019-06-21 22:12:44,464 - Mapswipe Workers - INFO - created vertical_slice
No overlapping groups.
2019-06-21 22:12:44,553 - Mapswipe Workers - INFO - build_area_default_with_bing - create_groups - created groups dictionary
2019-06-21 22:12:44,555 - Mapswipe Workers - INFO - 5G9Ce2J7 - __init__ - start init
2019-06-21 22:12:44,556 - Mapswipe Workers - INFO - build_area_sentinel_wmts - validate geometry - input geometry is correct.
2019-06-21 22:12:44,557 - Mapswipe Workers - INFO - got geometry and extent from file
2019-06-21 22:12:44,558 - Mapswipe Workers - INFO - created vertical_slice
No overlapping groups.
2019-06-21 22:12:44,558 - Mapswipe Workers - INFO - build_area_sentinel_wmts - create_groups - created groups dictionary
2019-06-21 22:12:44,559 - Mapswipe Workers - INFO - 5G9Ce2J7 - __init__ - start init
2019-06-21 22:12:44,559 - Mapswipe Workers - INFO - change_detection_default_with_bing - validate geometry - input geometry is correct.
2019-06-21 22:12:44,560 - Mapswipe Workers - INFO - got geometry and extent from file
2019-06-21 22:12:44,581 - Mapswipe Workers - INFO - created vertical_slice
No overlapping groups.
2019-06-21 22:12:45,046 - Mapswipe Workers - INFO - change_detection_default_with_bing - create_groups - created groups dictionary
2019-06-21 22:12:45,052 - Mapswipe Workers - INFO - 5G9Ce2J7 - __init__ - start init
2019-06-21 22:12:45,053 - Mapswipe Workers - INFO - change_detection_uganda_planet_wms - validate geometry - input geometry is correct.
2019-06-21 22:12:45,054 - Mapswipe Workers - INFO - got geometry and extent from file
2019-06-21 22:12:45,055 - Mapswipe Workers - INFO - created vertical_slice
No overlapping groups.
2019-06-21 22:12:45,055 - Mapswipe Workers - INFO - change_detection_uganda_planet_wms - create_groups - created groups dictionary
2019-06-21 22:12:45,056 - Mapswipe Workers - INFO - 5G9Ce2J7 - __init__ - start init
2019-06-21 22:12:45,568 - Mapswipe Workers - INFO - footprint_polygon_geometries - __init__ - downloaded input geometries from url and saved as file: /var/lib/mapswipe_workers/input_geometries/raw_input_footprint_polygon_geometries.geojson
2019-06-21 22:12:46,184 - Mapswipe Workers - INFO - footprint_polygon_geometries - check_input_geometry - filtered correct input geometries and created file: /var/lib/mapswipe_workers/input_geometries/valid_input_footprint_polygon_geometries.geojson
2019-06-21 22:12:46,339 - Mapswipe Workers - INFO - footprint_polygon_geometries - create_groups - created groups dictionary
success
Traceback (most recent call last):
  File "/home/travis/build/vinaytota-optimizely/python-mapswipe-workers/mapswipe_workers/auth.py", line 73, in firebaseDB
    firebase_admin.get_app()
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/firebase_admin/__init__.py", line 138, in get_app
    'The default Firebase app does not exist. Make sure to initialize '
ValueError: The default Firebase app does not exist. Make sure to initialize the SDK by calling initialize_app().
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "test_initialize.py", line 61, in <module>
    fb_db = auth.firebaseDB()
  File "/home/travis/build/vinaytota-optimizely/python-mapswipe-workers/mapswipe_workers/auth.py", line 77, in firebaseDB
    cred = credentials.Certificate(SERVICE_ACCOUNT_KEY_PATH)
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/firebase_admin/credentials.py", line 83, in __init__
    with open(cert) as json_file:
FileNotFoundError: [Errno 2] No such file or directory: '/home/travis/.config/mapswipe_workers/serviceAccountKey.json'
failure: 1
```

I am looking into using https://github.com/firebase/firebase-tools to emulate firebase for tests, and believe I am close to getting it to work, and hope to provide a completely working CI configuration in the next few days, at which point I will update this pull request.
