### PR TITLE
Code style

### DIFF
--- a/mapswipe_workers/.pre-commit-config.yaml
+++ b/mapswipe_workers/.pre-commit-config.yaml
@@ -7,4 +7,3 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
-        args: ["--ignore=E501,W503"]

--- a/mapswipe_workers/setup.cfg
+++ b/mapswipe_workers/setup.cfg
@@ -5,7 +5,7 @@
 
 [flake8]
 # W503: https://github.com/python/black#line-breaks--binary-operators
-# max-line-lenght conform with Black
+# max-line-lenght = 88 to conform with Black
 ignore = "W503"
 inline-quotes = double
 max-line-length = 88

--- a/mapswipe_workers/setup.cfg
+++ b/mapswipe_workers/setup.cfg
@@ -1,0 +1,18 @@
+# All configuration for plugins and other utils is defined here.
+# Read more about `setup.cfg`:
+# https://docs.python.org/3/distutils/configfile.html
+
+
+[flake8]
+# W503: https://github.com/python/black#line-breaks--binary-operators
+# max-line-lenght conform with Black
+ignore = "W503"
+inline-quotes = double
+max-line-length = 88
+
+
+[isort]
+# https://github.com/timothycrosley/isort/wiki/isort-Settings
+# See https://github.com/timothycrosley/isort#multi-line-output-modes
+include_trailing_comma = true
+multi_line_output = 3


### PR DESCRIPTION
Add setup.cfg to configure python plugins and utils like flake8.
Removed arguments from pre-commit-hook commands because of setup.cfg.