### PR TITLE
Add project types as global var to definitions.

### DIFF
--- a/mapswipe_workers/mapswipe_workers/definitions.py
+++ b/mapswipe_workers/mapswipe_workers/definitions.py
@@ -1,40 +1,41 @@
-import os
-import json
 import logging
 import logging.config
-from logging.handlers import TimedRotatingFileHandler
+import os
 
+from mapswipe_workers.project_types.build_area.build_area_project import (
+    BuildAreaProject,
+)
+from mapswipe_workers.project_types.change_detection.change_detection_project import (
+    ChangeDetectionProject,
+)
+from mapswipe_workers.project_types.footprint.footprint_project import FootprintProject
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
-CONFIG_DIR = os.path.abspath(
-        '/usr/share/config/mapswipe_workers/'
-        )
+CONFIG_DIR = os.path.abspath("/usr/share/config/mapswipe_workers/")
 
-CONFIG_PATH = os.path.join(
-        CONFIG_DIR,
-        'configuration.json'
-        )
+CONFIG_PATH = os.path.join(CONFIG_DIR, "configuration.json")
 
-SERVICE_ACCOUNT_KEY_PATH = os.path.join(
-        CONFIG_DIR,
-        'serviceAccountKey.json'
-        )
+SERVICE_ACCOUNT_KEY_PATH = os.path.join(CONFIG_DIR, "serviceAccountKey.json")
 
-LOGGING_CONFIG_PATH = os.path.join(
-        CONFIG_DIR,
-        'logging.cfg'
-        )
+LOGGING_CONFIG_PATH = os.path.join(CONFIG_DIR, "logging.cfg")
 
-DATA_PATH = os.path.abspath(
-        '/var/lib/mapswipe_workers/'
-        )
+DATA_PATH = os.path.abspath("/var/lib/mapswipe_workers/")
 
-logging.config.fileConfig(
-        fname=LOGGING_CONFIG_PATH,
-        disable_existing_loggers=True
-        )
-logger = logging.getLogger('Mapswipe Workers')
+PROJECT_TYPE_CLASSES = {
+    1: BuildAreaProject,
+    2: FootprintProject,
+    3: ChangeDetectionProject,
+}
+
+PROJECT_TYPE_NAMES = {
+    1: BuildAreaProject.name,
+    2: FootprintProject.name,
+    3: ChangeDetectionProject.name,
+}
+
+logging.config.fileConfig(fname=LOGGING_CONFIG_PATH, disable_existing_loggers=True)
+logger = logging.getLogger("Mapswipe Workers")
 
 
 class CustomError(Exception):

--- a/mapswipe_workers/mapswipe_workers/definitions.py
+++ b/mapswipe_workers/mapswipe_workers/definitions.py
@@ -29,9 +29,9 @@ PROJECT_TYPE_CLASSES = {
 }
 
 PROJECT_TYPE_NAMES = {
-    1: BuildAreaProject.name,
-    2: FootprintProject.name,
-    3: ChangeDetectionProject.name,
+    1: BuildAreaProject.project_type_name,
+    2: FootprintProject.project_type_name,
+    3: ChangeDetectionProject.project_type_name,
 }
 
 logging.config.fileConfig(fname=LOGGING_CONFIG_PATH, disable_existing_loggers=True)

--- a/mapswipe_workers/mapswipe_workers/project_types/build_area/build_area_project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/build_area/build_area_project.py
@@ -17,6 +17,7 @@ class BuildAreaProject(BaseProject):
     """
 
     projectType = 1
+    projectTypeName = "Build Area"
 
     def __init__(self, project_draft):
         # this will create the basis attributes

--- a/mapswipe_workers/mapswipe_workers/project_types/build_area/build_area_project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/build_area/build_area_project.py
@@ -16,8 +16,8 @@ class BuildAreaProject(BaseProject):
     The subclass for an import of the type Footprint
     """
 
-    projectType = 1
-    projectTypeName = "Build Area"
+    project_type = 1
+    project_type_name = "Build Area"
 
     def __init__(self, project_draft):
         # this will create the basis attributes

--- a/mapswipe_workers/mapswipe_workers/project_types/change_detection/change_detection_project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/change_detection/change_detection_project.py
@@ -18,8 +18,8 @@ class ChangeDetectionProject(BaseProject):
     The subclass for an import of the type Footprint
     """
 
-    projectType = 1
-    projectTypeName = "Change Detection"
+    project_type = 3
+    project_type_name = "Change Detection"
 
     def __init__(self, project_draft):
         # this will create the basis attributes

--- a/mapswipe_workers/mapswipe_workers/project_types/change_detection/change_detection_project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/change_detection/change_detection_project.py
@@ -19,6 +19,7 @@ class ChangeDetectionProject(BaseProject):
     """
 
     projectType = 1
+    projectTypeName = "Change Detection"
 
     def __init__(self, project_draft):
         # this will create the basis attributes

--- a/mapswipe_workers/mapswipe_workers/project_types/footprint/footprint_project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/footprint/footprint_project.py
@@ -17,6 +17,7 @@ class FootprintProject(BaseProject):
     """
 
     projectType = 2
+    projectTypeName = "Footprint"
 
     def __init__(self, project_draft):
         # this will create the basis attributes

--- a/mapswipe_workers/mapswipe_workers/project_types/footprint/footprint_project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/footprint/footprint_project.py
@@ -15,8 +15,8 @@ class FootprintProject(BaseProject):
     The subclass for an import of the type Footprint
     """
 
-    projectType = 2
-    projectTypeName = "Footprint"
+    project_type = 2
+    project_type_name = "Footprint"
 
     def __init__(self, project_draft):
         # this will create the basis attributes

--- a/mapswipe_workers/mapswipe_workers/project_types/footprint/footprint_project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/footprint/footprint_project.py
@@ -7,8 +7,7 @@ from mapswipe_workers.definitions import CustomError
 from mapswipe_workers.definitions import logger
 from mapswipe_workers.base.base_project import BaseProject
 from mapswipe_workers.project_types.footprint import grouping_functions as g
-from mapswipe_workers.project_types.footprint.footprint_group \
-        import FootprintGroup
+from mapswipe_workers.project_types.footprint.footprint_group import FootprintGroup
 
 
 class FootprintProject(BaseProject):
@@ -24,42 +23,40 @@ class FootprintProject(BaseProject):
         super().__init__(project_draft)
 
         # set group size
-        self.groupSize = project_draft['groupSize']
-        self.inputGeometries = project_draft['inputGeometries']
-        self.tileServer = self.get_tile_server(project_draft['tileServer'])
+        self.groupSize = project_draft["groupSize"]
+        self.inputGeometries = project_draft["inputGeometries"]
+        self.tileServer = self.get_tile_server(project_draft["tileServer"])
 
     def validate_geometries(self):
         raw_input_file = (
-                f'{DATA_PATH}/'
-                f'input_geometries/raw_input_{self.projectId}.geojson'
-                )
+            f"{DATA_PATH}/" f"input_geometries/raw_input_{self.projectId}.geojson"
+        )
         valid_input_file = (
-                f'{DATA_PATH}/'
-                f'input_geometries/valid_input_{self.projectId}.geojson'
-                )
+            f"{DATA_PATH}/" f"input_geometries/valid_input_{self.projectId}.geojson"
+        )
 
-        if not os.path.isdir('{}/input_geometries'.format(DATA_PATH)):
-            os.mkdir('{}/input_geometries'.format(DATA_PATH))
+        if not os.path.isdir("{}/input_geometries".format(DATA_PATH)):
+            os.mkdir("{}/input_geometries".format(DATA_PATH))
 
         # download file from given url
         url = self.inputGeometries
         urllib.request.urlretrieve(url, raw_input_file)
         logger.info(
-                f'{self.projectId}'
-                f' - __init__ - '
-                f'downloaded input geometries from url and saved as file: '
-                f'{raw_input_file}'
-                )
+            f"{self.projectId}"
+            f" - __init__ - "
+            f"downloaded input geometries from url and saved as file: "
+            f"{raw_input_file}"
+        )
         self.inputGeometries = raw_input_file
 
         # open the raw input file and get layer
-        driver = ogr.GetDriverByName('GeoJSON')
+        driver = ogr.GetDriverByName("GeoJSON")
         datasource = driver.Open(raw_input_file, 0)
         try:
             layer = datasource.GetLayer()
             LayerDefn = layer.GetLayerDefn()
         except AttributeError:
-            raise CustomError('Value error in input geometries file')
+            raise CustomError("Value error in input geometries file")
 
         # create layer for valid_input_file to store all valid geometries
         outDriver = ogr.GetDriverByName("GeoJSON")
@@ -68,9 +65,8 @@ class FootprintProject(BaseProject):
             outDriver.DeleteDataSource(valid_input_file)
         outDataSource = outDriver.CreateDataSource(valid_input_file)
         outLayer = outDataSource.CreateLayer(
-                "geometries",
-                geom_type=ogr.wkbMultiPolygon
-                )
+            "geometries", geom_type=ogr.wkbMultiPolygon
+        )
         for i in range(0, LayerDefn.GetFieldCount()):
             fieldDefn = LayerDefn.GetFieldDefn(i)
             outLayer.CreateField(fieldDefn)
@@ -78,11 +74,9 @@ class FootprintProject(BaseProject):
 
         # check if raw_input_file layer is empty
         if layer.GetFeatureCount() < 1:
-            err = 'empty file. No geometries provided'
+            err = "empty file. No geometries provided"
             # TODO: How to user logger and exceptions?
-            logger.warning(
-                    f'{self.projectId} - check_input_geometry - {err}'
-                    )
+            logger.warning(f"{self.projectId} - check_input_geometry - {err}")
             raise Exception(err)
 
         # get geometry as wkt
@@ -107,19 +101,19 @@ class FootprintProject(BaseProject):
             if not feat_geom.IsValid():
                 layer.DeleteFeature(fid)
                 logger.warning(
-                    f'{self.projectId}'
-                    f' - check_input_geometries - '
-                    f'deleted invalid feature {fid}'
-                    )
+                    f"{self.projectId}"
+                    f" - check_input_geometries - "
+                    f"deleted invalid feature {fid}"
+                )
 
             # we accept only POLYGON or MULTIPOLYGON geometries
-            elif geom_name != 'POLYGON' and geom_name != 'MULTIPOLYGON':
+            elif geom_name != "POLYGON" and geom_name != "MULTIPOLYGON":
                 layer.DeleteFeature(fid)
                 logger.warning(
-                    f'{self.projectId}'
-                    f' - check_input_geometries - '
-                    f'deleted non polygon feature {fid}'
-                    )
+                    f"{self.projectId}"
+                    f" - check_input_geometries - "
+                    f"deleted non polygon feature {fid}"
+                )
 
             else:
                 # Create output Feature
@@ -127,17 +121,16 @@ class FootprintProject(BaseProject):
                 # Add field values from input Layer
                 for i in range(0, outLayerDefn.GetFieldCount()):
                     outFeature.SetField(
-                            outLayerDefn.GetFieldDefn(i).GetNameRef(),
-                            feature.GetField(i)
-                            )
+                        outLayerDefn.GetFieldDefn(i).GetNameRef(), feature.GetField(i)
+                    )
                 outFeature.SetGeometry(feat_geom)
                 outLayer.CreateFeature(outFeature)
                 outFeature = None
 
         # check if layer is empty
         if layer.GetFeatureCount() < 1:
-            err = 'no geometries left after checking validity and geometry type.'
-            logger.warning(f'{self.projectId} - check_input_geometry - {err}')
+            err = "no geometries left after checking validity and geometry type."
+            logger.warning(f"{self.projectId} - check_input_geometry - {err}")
             raise Exception(err)
 
         del datasource
@@ -147,11 +140,11 @@ class FootprintProject(BaseProject):
         self.validInputGeometries = valid_input_file
 
         logger.info(
-                f'{self.projectId}'
-                f' - check_input_geometry - '
-                f'filtered correct input geometries and created file: '
-                f'{valid_input_file}'
-                )
+            f"{self.projectId}"
+            f" - check_input_geometry - "
+            f"filtered correct input geometries and created file: "
+            f"{valid_input_file}"
+        )
         return wkt_geometry
 
     def create_groups(self):
@@ -159,18 +152,13 @@ class FootprintProject(BaseProject):
         The function to create groups of footprint geometries
         """
 
-        raw_groups = g.group_input_geometries(
-                self.validInputGeometries,
-                self.groupSize
-                )
+        raw_groups = g.group_input_geometries(self.validInputGeometries, self.groupSize)
 
         for group_id, item in raw_groups.items():
             group = FootprintGroup(self, group_id)
-            group.create_tasks(item['feature_ids'], item['feature_geometries'])
+            group.create_tasks(item["feature_ids"], item["feature_geometries"])
             self.groups.append(group)
 
         logger.info(
-                f'{self.projectId} '
-                f'- create_groups - '
-                f'created groups dictionary'
-                )
+            f"{self.projectId} " f"- create_groups - " f"created groups dictionary"
+        )


### PR DESCRIPTION
- Add project types as global var to definitions.
- Run Black.
- Make use of PROJECT_TYPES in mapswipe_workers.py
- Remove not needed imports in definitions.py and mapswipe_workers.py