### PR TITLE
Configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,15 +55,8 @@ services:
             - postgres
         command: mapswipe_workers --verbose run --schedule
         volumes:
-            - ./api-data:/var/lib/mapswipe_workers/api-data/:rw
-            - ./api-data/agg_results:/var/lib/mapswipe_workers/api-data/agg_results:rw
-            - ./api-data/groups:/var/lib/mapswipe_workers/api-data/groups:rw
-            - ./api-data/history:/var/lib/mapswipe_workers/api-data/history:rw
-            - ./api-data/projects:/var/lib/mapswipe_workers/api-data/projects:rw
-            - ./api-data/results:/var/lib/mapswipe_workers/api-data/results:rw
-            - ./api-data/tasks:/var/lib/mapswipe_workers/api-data/tasks:rw
-            - ./api-data/yes_maybe:/var/lib/mapswipe_workers/api-data/yes_maybe:rw
-            - ./api-data/hot_tm:/var/lib/mapswipe_workers/api-data/hot_tm:rw
+            - ./log:/var/lib/mapswipe_workers/:rw
+            - ./api-data:/home/mapswipe/.local/share/api-data/:rw
         restart: "no"
         networks:
             - mapswipe_workers

--- a/mapswipe_workers/Dockerfile
+++ b/mapswipe_workers/Dockerfile
@@ -2,6 +2,9 @@
 # Image includes python3.6, gdal-python, gdal-bin
 FROM osgeo/gdal:ubuntu-small-latest
 
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
 # Install pip
 RUN apt-get update
 RUN apt-get --yes install python3-pip

--- a/mapswipe_workers/Dockerfile
+++ b/mapswipe_workers/Dockerfile
@@ -16,7 +16,7 @@ RUN useradd --create-home --no-log-init --system --gid mapswipe mapswipe
 
 # Create directory for logs and make it accsesably for the mapswipe user
 RUN mkdir --parents /var/log/mapswipe_workers
-RUN chown mapswipe_workers: /var/log/mapswipe_workers/
+RUN chown mapswipe /var/log/mapswipe_workers/
 
 # Change user to mapswipe
 USER mapswipe

--- a/mapswipe_workers/Dockerfile
+++ b/mapswipe_workers/Dockerfile
@@ -2,6 +2,7 @@
 # Image includes python3.6, gdal-python, gdal-bin
 FROM osgeo/gdal:ubuntu-small-latest
 
+# Set C.UTF-8 locale as default (Needed by the Click library)
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
@@ -9,34 +10,28 @@ ENV LANG=C.UTF-8
 RUN apt-get update
 RUN apt-get --yes install python3-pip
 
-# Create directories for config, logs and data
-ARG config_dir=/usr/share/config/mapswipe_workers/
-ARG repo_dir=/usr/local/mapswipe_workers/
-ARG data_dir=/var/lib/mapswipe_workers/
-ARG logs_dir=/var/log/mapswipe_workers/
+# Create user mapswipe
+RUN groupadd --system mapswipe
+RUN useradd --create-home --no-log-init --system --gid mapswipe mapswipe
 
-RUN mkdir -p $config_dir
-RUN mkdir -p $repo_dir
-RUN mkdir -p $logs_dir
-RUN mkdir -p $data_dir
-RUN mkdir -p $data_dir"api-data"
-RUN mkdir -p $data_dir"api-data/agg_results/"
-RUN mkdir -p $data_dir"api-data/groups/"
-RUN mkdir -p $data_dir"api-data/history/"
-RUN mkdir -p $data_dir"api-data/projects/"
-RUN mkdir -p $data_dir"api-data/results/"
-RUN mkdir -p $data_dir"api-data/tasks/"
-RUN mkdir -p $data_dir"api-data/yes_maybe/"
-RUN mkdir -p $data_dir"api-data/hot_tm/"
+# Create directory for logs and make it accsesably for the mapswipe user
+RUN mkdir --parents /var/log/mapswipe_workers
+RUN chown mapswipe_workers: /var/log/mapswipe_workers/
+
+# Change user to mapswipe
+USER mapswipe
+WORKDIR /home/mapswipe
+
+# Create directories for config, data and logs
+RUN mkdir --parents .config/mapswipe_workers
 
 # Copy mapswipe workers repo from local repo
-WORKDIR $repo_dir
 COPY mapswipe_workers/ mapswipe_workers/
 COPY sample_data/ sample_data/
 COPY tests/ tests/
 COPY requirements.txt .
 COPY setup.py .
-COPY config $config_dir
+COPY config/ .config/mapswipe_workers/
 
 # Update setuptools and install mapswipe-workers with dependencies (requirements.txt)
 RUN pip3 install --upgrade setuptools

--- a/mapswipe_workers/mapswipe_workers/definitions.py
+++ b/mapswipe_workers/mapswipe_workers/definitions.py
@@ -33,5 +33,10 @@ DATA_PATH = os.path.abspath("/var/lib/mapswipe_workers/")
 logging.config.fileConfig(fname=LOGGING_CONFIG_PATH, disable_existing_loggers=True)
 logger = logging.getLogger("Mapswipe Workers")
 
-sentry_sdk.init(CONFIG["sentry"]["dsn"])
+try:
+    sentry_sdk.init(CONFIG["sentry"]["dsn"])
+except KeyError:
+    logger.info(
+        "No configuration for Sentry was found. Continue without Sentry integration."
+    )
 sentry = sentry_sdk

--- a/mapswipe_workers/mapswipe_workers/definitions.py
+++ b/mapswipe_workers/mapswipe_workers/definitions.py
@@ -4,6 +4,7 @@ import logging.config
 import os
 
 import sentry_sdk
+from xdg import XDG_CONFIG_HOME, XDG_DATA_HOME
 
 
 class CustomError(Exception):
@@ -16,9 +17,7 @@ def load_config(CONFIG_PATH) -> dict:
         return json.load(f)
 
 
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-
-CONFIG_DIR = os.path.abspath("/usr/share/config/mapswipe_workers/")
+CONFIG_DIR = os.path.join(XDG_CONFIG_HOME, "mapswipe_workers/")
 
 CONFIG_PATH = os.path.join(CONFIG_DIR, "configuration.json")
 
@@ -28,7 +27,7 @@ SERVICE_ACCOUNT_KEY_PATH = os.path.join(CONFIG_DIR, "serviceAccountKey.json")
 
 LOGGING_CONFIG_PATH = os.path.join(CONFIG_DIR, "logging.cfg")
 
-DATA_PATH = os.path.abspath("/var/lib/mapswipe_workers/")
+DATA_PATH = os.path.join(XDG_DATA_HOME, "mapswipe_workers/")
 
 logging.config.fileConfig(fname=LOGGING_CONFIG_PATH, disable_existing_loggers=True)
 logger = logging.getLogger("Mapswipe Workers")

--- a/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
+++ b/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
@@ -173,7 +173,7 @@ def run_create_tutorial(input_file) -> None:
         sentry.capture_exception()
 
 
-@click.command("archive")
+@cli.command("archive")
 @click.option(
     "--project-id", "-i", help=("Archive project with giving project id"), type=str,
 )
@@ -195,7 +195,7 @@ def run_archive_project(project_id, project_ids):
     archive_project.archive_project(project_ids)
 
 
-@click.command("run")
+@cli.command("run")
 @click.option(
     "--schedule", is_flag=True, help=("Schedule jobs to run every 10 minutes.")
 )

--- a/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
+++ b/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
@@ -24,6 +24,7 @@ from mapswipe_workers.project_types.change_detection.change_detection_project im
 )
 from mapswipe_workers.project_types.footprint.footprint_project import FootprintProject
 from mapswipe_workers.utils import user_management
+from mapswipe_workers.utils.create_directories import create_directories
 from mapswipe_workers.utils.slack_helper import send_slack_message
 
 
@@ -41,6 +42,7 @@ class PythonLiteralOption(click.Option):
 @click.version_option()
 def cli(verbose):
     """Enable logging."""
+    create_directories()
     if not verbose:
         logger.disabled = True
 

--- a/mapswipe_workers/mapswipe_workers/utils/create_directories.py
+++ b/mapswipe_workers/mapswipe_workers/utils/create_directories.py
@@ -1,0 +1,29 @@
+import os
+
+from mapswipe_workers.definitions import DATA_PATH, logger, sentry
+
+
+def create_directories() -> None:
+    """Create directories for statistics"""
+    dirs = (
+        DATA_PATH + "api-data",
+        DATA_PATH + "api-data/agg_results",
+        DATA_PATH + "api-data/groups",
+        DATA_PATH + "api-data/history",
+        DATA_PATH + "api-data/hot_tm",
+        DATA_PATH + "api-data/projects",
+        DATA_PATH + "api-data/results",
+        DATA_PATH + "api-data/tasks",
+        DATA_PATH + "api-data/yes_maybe",
+    )
+
+    for path in dirs:
+        if not os.path.exists(path):
+            try:
+                os.makedirs(path)
+            except OSError:
+                logger.exception("Creation of the directory {0} failed".format(path))
+                sentry.capture_exception()
+                break
+            else:
+                print("Successfully created the directory {0}".format(path))

--- a/mapswipe_workers/requirements.txt
+++ b/mapswipe_workers/requirements.txt
@@ -10,3 +10,4 @@ python-dateutil==2.8.1
 schedule==0.6.0
 sentry-sdk==0.14.0
 slackclient==2.5.0
+xdg==4.0.1


### PR DESCRIPTION
- Change paths handling.
    - Directory creation for api data is now been done by python-mapswipe_workers in
Python.
    - Create user Mapswipe in Dockerfile and use XDG Base Directory Specification for config and data directories. This will make it easier to deploy and run mapswipe_workers without using docker (e.g. locally ona computer during development or running tests).
- Create dirs for api data if not exists on each run of mapswipe_workers cli.
- If no Sentry configuration is provided continue without Sentry integration.