### PR TITLE
Fix update users download

### DIFF
--- a/docs/source/user_contributions_transition.md
+++ b/docs/source/user_contributions_transition.md
@@ -1,0 +1,28 @@
+# User contributions transition
+
+## 1. Step release of new firebase functions
+Once the dev branch incorporating [pull #372](https://github.com/mapswipe/python-mapswipe-workers/pull/372) is merged into master firebase functions and database rules will be updated.
+
+From this time on, the firebase functions will write to both:
+* `v2/users/{user_id}/contributiobs`
+* `v2/userContributions/`
+
+This has no effect on the app, since all data is still available as before. Also the counters for `taskContributionCount` or `projectContributionCount` are still based on the old data.
+
+From now on user contributions will just be stored at both places. 
+
+Once the new firebase functions and database rules have been released to the production server, we will copy all data that is available under `v2/users/{user_id}/contributions` to `v2/userContributions`. This makes sure that from now on both paths have exactly the same data.
+
+## 2. Step release of new MapSwipe client version
+We should release a new version of the MapSwipe app. This version should check which groups a user has been completed under the new path at `v2/userContributions`.
+
+After releasing the app, we will wait untill close to 100% of all active users have adopted the new version. This can be checked in Firebase [here](https://console.firebase.google.com/project/msf-mapswipe/analytics/app/ios:org.missingmaps.mapswipe/latestrelease/).
+
+## 3. Adjust Firebase Functions
+Once all users use the latest version of the app, we can change Firebase functions again.
+
+Remove all functions using `contributionsRef` and `groupContributionsRef`
+
+Activate / Uncomment all functions using `contributionsRefNew` and `groupContributionsRefNew`.
+
+You are done. :)

--- a/docs/source/user_contributions_transition.md
+++ b/docs/source/user_contributions_transition.md
@@ -3,6 +3,10 @@
 ## 1. Step release of new firebase functions
 Once the dev branch incorporating [pull #372](https://github.com/mapswipe/python-mapswipe-workers/pull/372) is merged into master firebase functions and database rules will be updated.
 
+You can do this also manually:
+* `docker-compose build --no-cache firebase_deploy`
+* `docker-compose run -d firebase_deploy`
+
 From this time on, the firebase functions will write to both:
 * `v2/users/{user_id}/contributiobs`
 * `v2/userContributions/`
@@ -12,6 +16,10 @@ This has no effect on the app, since all data is still available as before. Also
 From now on user contributions will just be stored at both places. 
 
 Once the new firebase functions and database rules have been released to the production server, we will copy all data that is available under `v2/users/{user_id}/contributions` to `v2/userContributions`. This makes sure that from now on both paths have exactly the same data.
+
+You have to run this script manually:
+* `docker-compose build --no-cache mapswipe_workers`
+* `docker-compose run -d mapswipe_workers python3 python_scripts/copy_user_contributions_in_firebase.py`
 
 ## 2. Step release of new MapSwipe client version
 We should release a new version of the MapSwipe app. This version should check which groups a user has been completed under the new path at `v2/userContributions`.

--- a/docs/source/user_contributions_transition.md
+++ b/docs/source/user_contributions_transition.md
@@ -20,7 +20,7 @@ Once the new firebase functions and database rules have been released to the pro
 You have to run this script manually:
 * `docker-compose build --no-cache mapswipe_workers`
 * `docker-compose run -d mapswipe_workers python3 python_scripts/copy_user_contributions_in_firebase.py`
-
+py
 This might take some time.
 
 ## 2. Step release of new MapSwipe client version

--- a/docs/source/user_contributions_transition.md
+++ b/docs/source/user_contributions_transition.md
@@ -21,6 +21,8 @@ You have to run this script manually:
 * `docker-compose build --no-cache mapswipe_workers`
 * `docker-compose run -d mapswipe_workers python3 python_scripts/copy_user_contributions_in_firebase.py`
 
+This might take some time.
+
 ## 2. Step release of new MapSwipe client version
 We should release a new version of the MapSwipe app. This version should check which groups a user has been completed under the new path at `v2/userContributions`.
 

--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -62,58 +62,17 @@
         ".indexOn": [
           "created"
         ]
-      }
-    },
-    "groups": {
-      ".write": false,
-      ".read": true,
-      "$project_id": {
-        "$group_id": {
-          ".indexOn": [
-            "distributedCount",
-            "completedCount"
-          ],
-          ".write": "auth != null",
-          "completedCount": {
-            ".write": "auth != null"
-          }
+      },
+      "userContributions": {
+        ".write": false,
+        ".read": false,
+        "$uid": {
+          ".read": "auth != null && auth.uid == $uid"
         },
         ".indexOn": [
-          "distributedCount",
-          "completedCount"
+          "projectId"
         ]
       }
-    },
-    "imports": {
-      ".read": false,
-      ".write": true,
-      ".indexOn": [
-        "complete"
-      ]
-    },
-    "projects": {
-      ".write": false,
-      ".read": true
-    },
-    "announcement": {
-      ".write": true,
-      ".read": true
-    },
-    "results": {
-      ".write": false,
-      ".read": true,
-      "$task_id": {
-        "$user_id": {
-          ".write": "auth != null && auth.uid == $user_id"
-        }
-      }
-    },
-    "users": {
-      "$uid": {
-        ".read": "auth != null && auth.uid == $uid",
-        ".write": "auth != null && auth.uid == $uid"
-      },
-      ".read": true
     }
   }
 }

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -47,6 +47,9 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
     const groupContributionsRef         = admin.database().ref('/v2/userContributions/'+context.params.userId+'/'+context.params.projectId +'/'+context.params.groupId)
     const totalTimeSpentMappingRef      = admin.database().ref('/v2/users/'+context.params.userId+'/timeSpentMapping')
 
+    const contributionsRefOld           = admin.database().ref('/v2/users/'+context.params.userId+'/contributions/'+context.params.projectId)
+    const groupContributionsRefOld      = admin.database().ref('/v2/users/'+context.params.userId+'/contributions/'+context.params.projectId +'/'+context.params.groupId)
+
     const timestampRef          = admin.database().ref('/v2/results/'+context.params.projectId+'/'+context.params.groupId+'/'+context.params.userId+'/timestamp')
     const startTimeRef          = admin.database().ref('/v2/results/'+context.params.projectId+'/'+context.params.groupId+'/'+context.params.userId+'/startTime')
     const endTimeRef            = admin.database().ref('/v2/results/'+context.params.projectId+'/'+context.params.groupId+'/'+context.params.userId+'/endTime')
@@ -123,6 +126,23 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
             }
         })
     promises.push(contributions)
+
+    // this can removed once all clients don't need this data in Firebase
+    const contributionsOld = groupContributionsRefOld.once('value')
+        .then((dataSnapshot) => {
+            if (dataSnapshot.exists()) {
+                return null
+            }
+            else {
+            const data = {
+                'timestamp': result['timestamp'],
+                'startTime': result['startTime'],
+                'endTime': result['endTime']
+             }
+             return groupContributionsRefOld.set(data)
+            }
+        })
+    promises.push(contributionsOld)
 
     // // TODO: Does not work
     // const timeSpentMapping = timeSpentMappingRef.set((timeSpentMapping) => {

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -43,12 +43,12 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
     const taskContributionCountRef      = admin.database().ref('/v2/users/'+context.params.userId+'/taskContributionCount')
     const groupContributionCountRef     = admin.database().ref('/v2/users/'+context.params.userId+'/groupContributionCount')
     const projectContributionCountRef   = admin.database().ref('/v2/users/'+context.params.userId+'/projectContributionCount')
-    const contributionsRefNew              = admin.database().ref('/v2/userContributions/'+context.params.userId+'/'+context.params.projectId)
-    const groupContributionsRefNew         = admin.database().ref('/v2/userContributions/'+context.params.userId+'/'+context.params.projectId +'/'+context.params.groupId)
-    const totalTimeSpentMappingRef      = admin.database().ref('/v2/users/'+context.params.userId+'/timeSpentMapping')
-
     const contributionsRef              = admin.database().ref('/v2/users/'+context.params.userId+'/contributions/'+context.params.projectId)
     const groupContributionsRef         = admin.database().ref('/v2/users/'+context.params.userId+'/contributions/'+context.params.projectId +'/'+context.params.groupId)
+    const totalTimeSpentMappingRef      = admin.database().ref('/v2/users/'+context.params.userId+'/timeSpentMapping')
+
+    const contributionsRefNew           = admin.database().ref('/v2/userContributions/'+context.params.userId+'/'+context.params.projectId)
+    const groupContributionsRefNew      = admin.database().ref('/v2/userContributions/'+context.params.userId+'/'+context.params.projectId +'/'+context.params.groupId)
 
     const timestampRef          = admin.database().ref('/v2/results/'+context.params.projectId+'/'+context.params.groupId+'/'+context.params.userId+'/timestamp')
     const startTimeRef          = admin.database().ref('/v2/results/'+context.params.projectId+'/'+context.params.groupId+'/'+context.params.userId+'/startTime')
@@ -178,7 +178,7 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
                 'startTime': result['startTime'],
                 'endTime': result['endTime']
              }
-             return groupContributionsRefOld.set(data)
+             return groupContributionsRefNew.set(data)
             }
         })
     promises.push(contributionsNew)

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -43,12 +43,12 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
     const taskContributionCountRef      = admin.database().ref('/v2/users/'+context.params.userId+'/taskContributionCount')
     const groupContributionCountRef     = admin.database().ref('/v2/users/'+context.params.userId+'/groupContributionCount')
     const projectContributionCountRef   = admin.database().ref('/v2/users/'+context.params.userId+'/projectContributionCount')
-    const contributionsRef              = admin.database().ref('/v2/userContributions/'+context.params.userId+'/'+context.params.projectId)
-    const groupContributionsRef         = admin.database().ref('/v2/userContributions/'+context.params.userId+'/'+context.params.projectId +'/'+context.params.groupId)
+    const contributionsRefNew              = admin.database().ref('/v2/userContributions/'+context.params.userId+'/'+context.params.projectId)
+    const groupContributionsRefNew         = admin.database().ref('/v2/userContributions/'+context.params.userId+'/'+context.params.projectId +'/'+context.params.groupId)
     const totalTimeSpentMappingRef      = admin.database().ref('/v2/users/'+context.params.userId+'/timeSpentMapping')
 
-    const contributionsRefOld           = admin.database().ref('/v2/users/'+context.params.userId+'/contributions/'+context.params.projectId)
-    const groupContributionsRefOld      = admin.database().ref('/v2/users/'+context.params.userId+'/contributions/'+context.params.projectId +'/'+context.params.groupId)
+    const contributionsRef              = admin.database().ref('/v2/users/'+context.params.userId+'/contributions/'+context.params.projectId)
+    const groupContributionsRef         = admin.database().ref('/v2/users/'+context.params.userId+'/contributions/'+context.params.projectId +'/'+context.params.groupId)
 
     const timestampRef          = admin.database().ref('/v2/results/'+context.params.projectId+'/'+context.params.groupId+'/'+context.params.userId+'/timestamp')
     const startTimeRef          = admin.database().ref('/v2/results/'+context.params.projectId+'/'+context.params.groupId+'/'+context.params.userId+'/startTime')
@@ -67,6 +67,8 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
     promises.push(groupRequiredCount)
 
     // Counter for projects
+    // This should be removed once all mapswipe clients
+    //   can deal with user contributions at `v2/userContributions`
     const contributorsCount = contributionsRef.once('value')
         .then((dataSnapshot) => {
             if (dataSnapshot.exists()) {
@@ -79,6 +81,24 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
             }
         })
     promises.push(contributorsCount)
+
+    // Counter for projects
+    // This should be activated once all mapswipe clients
+    //   can deal with user contributions at `v2/userContributions`
+    /*
+    const contributorsCount = contributionsRefNew.once('value')
+        .then((dataSnapshot) => {
+            if (dataSnapshot.exists()) {
+                return null
+            }
+            else {
+                return contributorsCountRef.transaction((currentCount) => {
+                    return currentCount + 1
+                })
+            }
+        })
+    promises.push(contributorsCount)
+    */
 
     // Counter for users
     const projectContributionCount = contributionsRef.once('value')
@@ -93,6 +113,24 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
             }
         })
     promises.push(projectContributionCount)
+
+    // Counter for users
+    // This should be activated once all mapswipe clients
+    //   can deal with user contributions at `v2/userContributions`
+    /*
+    const projectContributionCount = contributionsRefNew.once('value')
+        .then((dataSnapshot) => {
+            if (dataSnapshot.exists()) {
+                return null
+            }
+            else {
+                return projectContributionCountRef.transaction((currentCount) => {
+                    return currentCount + 1
+                })
+            }
+        })
+    promises.push(projectContributionCount)
+    */
 
     const groupContributionCount = groupContributionCountRef.transaction((currentCount) => {
         return currentCount + 1
@@ -111,6 +149,8 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
         })
     promises.push(taskContributionCount)
 
+    // This should be removed once all mapswipe clients
+    //   can deal with user contributions at `v2/userContributions`
     const contributions = groupContributionsRef.once('value')
         .then((dataSnapshot) => {
             if (dataSnapshot.exists()) {
@@ -127,8 +167,7 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
         })
     promises.push(contributions)
 
-    // this can removed once all clients don't need this data in Firebase
-    const contributionsOld = groupContributionsRefOld.once('value')
+    const contributionsNew = groupContributionsRefNew.once('value')
         .then((dataSnapshot) => {
             if (dataSnapshot.exists()) {
                 return null
@@ -142,7 +181,7 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
              return groupContributionsRefOld.set(data)
             }
         })
-    promises.push(contributionsOld)
+    promises.push(contributionsNew)
 
     // // TODO: Does not work
     // const timeSpentMapping = timeSpentMappingRef.set((timeSpentMapping) => {

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -43,8 +43,8 @@ exports.counter = functions.database.ref('/v2/results/{projectId}/{groupId}/{use
     const taskContributionCountRef      = admin.database().ref('/v2/users/'+context.params.userId+'/taskContributionCount')
     const groupContributionCountRef     = admin.database().ref('/v2/users/'+context.params.userId+'/groupContributionCount')
     const projectContributionCountRef   = admin.database().ref('/v2/users/'+context.params.userId+'/projectContributionCount')
-    const contributionsRef              = admin.database().ref('/v2/users/'+context.params.userId+'/contributions/'+context.params.projectId)
-    const groupContributionsRef         = admin.database().ref('/v2/users/'+context.params.userId+'/contributions/'+context.params.projectId +'/'+context.params.groupId)
+    const contributionsRef              = admin.database().ref('/v2/userContributions/'+context.params.userId+'/'+context.params.projectId)
+    const groupContributionsRef         = admin.database().ref('/v2/userContributions/'+context.params.userId+'/'+context.params.projectId +'/'+context.params.groupId)
     const totalTimeSpentMappingRef      = admin.database().ref('/v2/users/'+context.params.userId+'/timeSpentMapping')
 
     const timestampRef          = admin.database().ref('/v2/results/'+context.params.projectId+'/'+context.params.groupId+'/'+context.params.userId+'/timestamp')

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -19,7 +19,7 @@
     "eslint-utils": "^1.4.1"
   },
   "engines": {
-    "node": "8"
+    "node": "10"
   },
   "private": true
 }

--- a/mapswipe_workers/mapswipe_workers/firebase_to_postgres/update_data.py
+++ b/mapswipe_workers/mapswipe_workers/firebase_to_postgres/update_data.py
@@ -46,6 +46,7 @@ def update_user_data(user_ids: list = []) -> None:
         # Get only new users from Firebase.
         query = ref.order_by_child("created").start_at(last_updated)
         users = query.get()
+
         if len(users) == 0:
             logger.info("there are no new users in Firebase.")
         else:
@@ -54,8 +55,11 @@ def update_user_data(user_ids: list = []) -> None:
             users.popitem(last=False)
     else:
         # Get all users from Firebase.
+        # TODO: you should never do this frequently since it will come very costly
+        #  this might be okay, if we move some of the data to another part in firebase
         users = ref.get()
 
+    logger.info(f"number of users retrieved from firebase: {len(users)}")
     for user_id, user in users.items():
         # Convert timestamp (ISO 8601) from string to a datetime object.
         try:
@@ -85,7 +89,7 @@ def update_user_data(user_ids: list = []) -> None:
             created,
         ]
         pg_db.query(query_update_user, data_update_user)
-    logger.info("Updated user data in Potgres.")
+    logger.info("Updated user data in Postgres.")
 
 
 def update_project_data(project_ids: list = []):

--- a/mapswipe_workers/python_scripts/copy_user_contributions_in_firebase.py
+++ b/mapswipe_workers/python_scripts/copy_user_contributions_in_firebase.py
@@ -1,0 +1,40 @@
+from mapswipe_workers.auth import firebaseDB
+from mapswipe_workers.definitions import logger
+
+
+def get_all_users():
+    """Get the user ids from all users in Firebase DB."""
+    fb_db = firebaseDB()
+    users = fb_db.reference(f"v2/users/").get(shallow=True)
+    uid_list = users.keys()
+    return uid_list
+
+
+def copy_user_contributions(uid):
+    """Copy user contributions in Firebase from `users` to `userContributions`."""
+    fb_db = firebaseDB()
+    try:
+        ref = fb_db.reference(f"v2/users/{uid}/contributions")
+        user_contributions = ref.get()
+        # only set username for users with display_name
+        if not user_contributions:
+            logger.info(f"user {uid} has no contributions in firebase.")
+        else:
+            for project_id in user_contributions.keys():
+                ref = fb_db.reference(f"v2/userContributions/{uid}/{project_id}/")
+                ref.update(user_contributions[project_id])
+                logger.info(
+                    f"updated user contributions for user {uid}, project {project_id}"
+                )
+    except ValueError:
+        logger.info(f"could copy user contributions in firebase for {uid}.")
+
+
+if __name__ == "__main__":
+    """Get users in Firebase and copy their contributions to `userContributions`."""
+    # TODO: add another process to delete all old contributions
+    #  once copied to new endpoint.
+    #  This might not be needed here immediately, but at some point in time.
+    uid_list = get_all_users()
+    for uid in uid_list:
+        copy_user_contributions(uid)

--- a/mapswipe_workers/python_scripts/copy_user_contributions_in_firebase.py
+++ b/mapswipe_workers/python_scripts/copy_user_contributions_in_firebase.py
@@ -16,7 +16,6 @@ def copy_user_contributions(uid):
     try:
         ref = fb_db.reference(f"v2/users/{uid}/contributions")
         user_contributions = ref.get()
-        # only set username for users with display_name
         if not user_contributions:
             logger.info(f"user {uid} has no contributions in firebase.")
         else:
@@ -33,7 +32,7 @@ def copy_user_contributions(uid):
             # ref.set(None)
 
     except ValueError:
-        logger.info(f"could copy user contributions in firebase for {uid}.")
+        logger.info(f"could not copy user contributions in firebase for {uid}.")
 
 
 if __name__ == "__main__":

--- a/mapswipe_workers/python_scripts/copy_user_contributions_in_firebase.py
+++ b/mapswipe_workers/python_scripts/copy_user_contributions_in_firebase.py
@@ -26,6 +26,12 @@ def copy_user_contributions(uid):
                 logger.info(
                     f"updated user contributions for user {uid}, project {project_id}"
                 )
+
+            # TODO: uncomment when we want to delete old contributions from firebase.
+            #  This should be done after all mapswipe clients can deal with it.
+            # ref = fb_db.reference(f"v2/users/{uid}/contributions/")
+            # ref.set(None)
+
     except ValueError:
         logger.info(f"could copy user contributions in firebase for {uid}.")
 

--- a/mapswipe_workers/tests/test_update_user_data.py
+++ b/mapswipe_workers/tests/test_update_user_data.py
@@ -1,0 +1,4 @@
+from mapswipe_workers.firebase_to_postgres.update_data import update_user_data
+
+if __name__ == "__main__":
+    update_user_data()


### PR DESCRIPTION
This introduces a new endpoint in firebase for user contributions `v2/userContributions`. Before this user contributions have been stored here `v2/users/{user_id}/contributions`. This resulted in unnecessary data download by the back end workers and the leader board. #371 

This pull request updates the firebase functions to set the user contributions to `v2/userContributions` whenever new results are uploaded to Firebase. In the state here, the firebase functions still update also the old path `v2/users/{user_id}/contributions`. This can be changed once all MapSwipe clients can deal with it. (The client queries the user contributions path to select groups a user has not been worked on already.) 
Additionally, this pull request comes with a script to copy the "old" user contributions to the new path in Firebase.

Firebase Functions are updated to Node.js 10. #360 

There is a document how to deploy these changes here: `docs/source/user_contributions.md`
