### PR TITLE
Feature private projects

### DIFF
--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -56,7 +56,7 @@
           ".read": "auth.token.projectManager === true",
           "teamName": {
             // team members read teamName
-            ".read": "(root.child('/v2/users/'+auth.uid+'/teamId').val() === $teamId) || (auth.token.projectManager === true)"
+            ".read": "(root.child('/v2/users/'+auth.uid+'/teamId').val() === $teamId)"
           },
           ".indexOn": [
             "teamName"

--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -5,17 +5,20 @@
     "v2": {
       "announcement": {
         ".write": false,
-        ".read": true
+        ".read": "auth != null"
       },
       "projects": {
-        ".write": false,
-        ".read": "auth != null",
+        // project managers can read/write all attributes
+        ".write": "auth.token.projectManager === true",
+        ".read": "auth.token.projectManager === true",
         "$project_id": {
-          "status": {
-            ".write": "auth.token.projectManager === true"
+          "teamId": {
+            // only team members can read
+            ".read": "root.child('/v2/users/'+auth.uid+'/teamId').val() === data.val()"
           },
-          "isFeatured": {
-            ".write": "auth.token.projectManager === true"
+          "$other": {
+            // all users can read, project managers can write
+            ".read": "auth != null"
           }
         },
         ".indexOn": [
@@ -23,6 +26,7 @@
           ]
       },
       "projectDrafts": {
+        // only project managers can write projectDrafts
         ".read": false,
         ".write": "auth.token.projectManager === true",
         ".indexOn": [
@@ -30,8 +34,9 @@
         ]
       },
       "groups": {
+        // users can read tasks, nobody can write
         ".write": false,
-        ".read": true,
+        ".read": "auth != null",
         "$project_id": {
           ".indexOn": [
             "finishedCount",
@@ -40,15 +45,23 @@
         }
       },
       "tasks": {
+        // users can read tasks, nobody can write
         ".write": false,
-        ".read": true
+        ".read": "auth != null"
       },
       "teams": {
-        ".write": "auth.token.projectManager === true",
-        ".read": "auth.token.projectManager === true",
-        ".indexOn": [
-          "teamName"
-        ]
+        "$teamId": {
+          // project managers can read/write all attributes
+          ".write": "auth.token.projectManager === true",
+          ".read": "auth.token.projectManager === true",
+          "teamName": {
+            // team members read teamName
+            ".read": "(root.child('/v2/users/'+auth.uid+'/teamId').val() === $teamId) || (auth.token.projectManager === true)"
+          },
+          ".indexOn": [
+            "teamName"
+          ]
+        }
       },
       "results": {
         ".write": false,

--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -91,56 +91,12 @@
         ]
       }
     },
-    "groups": {
-      ".write": false,
-      ".read": true,
-      "$project_id": {
-        "$group_id": {
-          ".indexOn": [
-            "distributedCount",
-            "completedCount"
-          ],
-          ".write": "auth != null",
-          "completedCount": {
-            ".write": "auth != null"
-          }
-        },
-        ".indexOn": [
-          "distributedCount",
-          "completedCount"
-        ]
-      }
-    },
-    "imports": {
-      ".read": false,
-      ".write": true,
-      ".indexOn": [
-        "complete"
-      ]
-    },
-    "projects": {
-      ".write": false,
-      ".read": true
-    },
-    "announcement": {
-      ".write": true,
-      ".read": true
-    },
-    "results": {
-      ".write": false,
-      ".read": true,
-      "$task_id": {
-        "$user_id": {
-          ".write": "auth != null && auth.uid == $user_id"
-        }
-      }
-    },
+    // leaving this here, since version before v2 pull data from there
     "users": {
       "$uid": {
         ".read": "auth != null && auth.uid == $uid",
         ".write": "auth != null && auth.uid == $uid"
-      },
-      ".read": true
+      }
     }
   }
 }

--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -81,7 +81,7 @@
           "teamId": {
             ".write": false
           },
-          "$other" {
+          "$other": {
             ".write": "auth != null && auth.uid == $uid"
           }
         },

--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -78,26 +78,11 @@
         ".read": true,
         ".write": false,
         "$uid": {
-          "username": {
-            ".write": "auth != null && auth.uid == $uid"
-          },
-          "created": {
-            ".write": "auth != null && auth.uid == $uid"
-          },
-          "lastAppUse": {
-            ".write": "auth != null && auth.uid == $uid"
-          },
-          "projectContributionCount": {
-            ".write": "auth != null && auth.uid == $uid"
-          },
-          "groupContributionCount": {
-            ".write": "auth != null && auth.uid == $uid"
-          },
-          "taskContributionCount": {
-            ".write": "auth != null && auth.uid == $uid"
-          },
           "teamId": {
             ".write": false
+          },
+          "$other" {
+            ".write": "auth != null && auth.uid == $uid"
           }
         },
         ".indexOn": [

--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -43,6 +43,13 @@
         ".write": false,
         ".read": true
       },
+      "teams": {
+        ".write": "auth.token.projectManager === true",
+        ".read": "auth.token.projectManager === true",
+        ".indexOn": [
+          "teamName"
+        ]
+      },
       "results": {
         ".write": false,
         ".read": false,
@@ -56,11 +63,33 @@
       },
       "users": {
         ".read": true,
+        ".write": false,
         "$uid": {
-          ".write": "auth != null && auth.uid == $uid"
+          "username": {
+            ".write": "auth != null && auth.uid == $uid"
+          },
+          "created": {
+            ".write": "auth != null && auth.uid == $uid"
+          },
+          "lastAppUse": {
+            ".write": "auth != null && auth.uid == $uid"
+          },
+          "projectContributionCount": {
+            ".write": "auth != null && auth.uid == $uid"
+          },
+          "groupContributionCount": {
+            ".write": "auth != null && auth.uid == $uid"
+          },
+          "taskContributionCount": {
+            ".write": "auth != null && auth.uid == $uid"
+          },
+          "teamId": {
+            ".write": false
+          }
         },
         ".indexOn": [
-          "created"
+          "created",
+          "teamId"
         ]
       }
     },

--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -19,7 +19,7 @@
           }
         },
         ".indexOn": [
-            "status", "isFeatured"
+            "status", "isFeatured", "teamId"
           ]
       },
       "projectDrafts": {

--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -10,20 +10,26 @@
       "projects": {
         // project managers can read/write all attributes
         ".write": "auth.token.projectManager === true",
-        ".read": "auth.token.projectManager === true",
+        ".read": "
+          // all users can query by status
+        	(auth != null  && query.orderByChild == 'status' && query.equalTo == 'active')
+          ||
+          // only team members can query by their own teamId
+          (auth != null && query.orderByChild == 'teamId' &&
+           query.equalTo == root.child('/v2/users/'+auth.uid+'/teamId').val())
+        ",
         "$project_id": {
-          "teamId": {
-            // only team members can read
-            ".read": "root.child('/v2/users/'+auth.uid+'/teamId').val() === data.val()"
-          },
-          "$other": {
-            // all users can read, project managers can write
-            ".read": "auth != null"
-          }
+         ".read": "
+            // all users can read all public projects
+            (data.child('teamId').exists() == false)
+            ||
+            // team members can read their projects
+            (data.child('teamId').val() == root.child('/v2/users/'+auth.uid+'/teamId').val())
+          "
         },
         ".indexOn": [
             "status", "isFeatured", "teamId"
-          ]
+        ]
       },
       "projectDrafts": {
         // only project managers can write projectDrafts
@@ -36,27 +42,44 @@
       "groups": {
         // users can read tasks, nobody can write
         ".write": false,
-        ".read": "auth != null",
+        ".read": false,
+        //".read": "auth != null",
         "$project_id": {
-          ".indexOn": [
-            "finishedCount",
-            "requiredCount"
-          ]
-        }
+          ".read": "
+            // everyone can read groups for public projects
+          	(root.child('/v2/projects/'+$project_id).hasChild('teamId') === false)
+            ||
+            (root.child('/v2/projects/'+$project_id+'/teamId').val() ==
+             root.child('/v2/users/'+auth.uid+'/teamId').val())
+          "
+        },
+        ".indexOn": [
+          "finishedCount",
+          "requiredCount"
+        ]
       },
       "tasks": {
         // users can read tasks, nobody can write
         ".write": false,
-        ".read": "auth != null"
+        "$project_id": {
+          ".read": "
+            // everyone can read groups for public projects
+          	(root.child('/v2/projects/'+$project_id).hasChild('teamId') === false)
+            ||
+            (root.child('/v2/projects/'+$project_id+'/teamId').val() ==
+             root.child('/v2/users/'+auth.uid+'/teamId').val())
+          "
+        },
       },
       "teams": {
+        // project managers can read/write all attributes
+        ".write": "auth.token.projectManager === true",
+        ".read": "auth.token.projectManager === true",
         "$teamId": {
-          // project managers can read/write all attributes
-          ".write": "auth.token.projectManager === true",
-          ".read": "auth.token.projectManager === true",
           "teamName": {
             // team members read teamName
             ".read": "(root.child('/v2/users/'+auth.uid+'/teamId').val() === $teamId)"
+            //".read": "auth != null"
           },
           ".indexOn": [
             "teamName"

--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -8,8 +8,7 @@
         ".read": "auth != null"
       },
       "projects": {
-        // project managers can read/write all attributes
-        ".write": "auth.token.projectManager === true",
+        ".write": false,
         ".read": "
           // all users can query by status
         	(auth != null  && query.orderByChild == 'status' && query.equalTo == 'active')
@@ -17,8 +16,13 @@
           // only team members can query by their own teamId
           (auth != null && query.orderByChild == 'teamId' &&
            query.equalTo == root.child('/v2/users/'+auth.uid+'/teamId').val())
+          ||
+          // project managers can read all
+          (auth.token.projectManager === true)
         ",
         "$project_id": {
+         // project managers can read/write all attributes
+         ".write": "auth.token.projectManager === true",
          ".read": "
             // all users can read all public projects
             (data.child('teamId').exists() == false)
@@ -40,10 +44,8 @@
         ]
       },
       "groups": {
-        // users can read tasks, nobody can write
         ".write": false,
-        ".read": false,
-        //".read": "auth != null",
+        ".read": "auth.token.projectManager === true",
         "$project_id": {
           ".read": "
             // everyone can read groups for public projects
@@ -59,8 +61,8 @@
         ]
       },
       "tasks": {
-        // users can read tasks, nobody can write
         ".write": false,
+        ".read": "auth.token.projectManager === true",
         "$project_id": {
           ".read": "
             // everyone can read groups for public projects
@@ -72,10 +74,11 @@
         },
       },
       "teams": {
-        // project managers can read/write all attributes
-        ".write": "auth.token.projectManager === true",
+        ".write": false,
+        // project managers can read all attributes
         ".read": "auth.token.projectManager === true",
         "$teamId": {
+          ".write": "auth.token.projectManager === true",
           "teamName": {
             // team members read teamName
             ".read": "(root.child('/v2/users/'+auth.uid+'/teamId').val() === $teamId)"
@@ -92,7 +95,17 @@
         "$project_id": {
           "$group_id": {
             "$uid": {
-              ".write": "$uid === auth.uid"
+              ".write": "
+                // everyone can write results for public projects
+                (root.child('/v2/projects/'+$project_id).hasChild('teamId') === false &&
+                 auth.uid == $uid
+                )
+                ||
+                (root.child('/v2/projects/'+$project_id+'/teamId').val() ==
+                 root.child('/v2/users/'+auth.uid+'/teamId').val() &&
+                 auth.uid == $uid
+                )
+              "
             }
           }
         }

--- a/manager_dashboard/manager_dashboard/create.html
+++ b/manager_dashboard/manager_dashboard/create.html
@@ -137,6 +137,13 @@
                               <span>We will generate you project name based on your inputs above.</span>
                           </li>
                           <li>
+                              <label for="visibility">Visibility</label>
+                              <select name="visibility" id="visibility">
+                                  <option value="public">Public</option>
+                              </select>
+                              <span>Choose either "public" or select the team for which this project should be displayed.</span>
+                          </li>
+                          <li>
                               <label for="lookFor">Look For</label>
                               <input type="text" name="lookFor" id="lookFor" maxlength="25" required>
                               <span>What should the users look for (e.g. buildings, cars, trees)? (15 chars max).</span>

--- a/manager_dashboard/manager_dashboard/create.html
+++ b/manager_dashboard/manager_dashboard/create.html
@@ -65,10 +65,13 @@
         <li class="nav-item active">
           <a class="nav-link" href="create.html">CREATE PROJECTS</a>
         </li>
-        <li class="nav-item active">
+        <li class="nav-item">
           <a class="nav-link" href="manage.html">MANAGE PROJECTS</a>
         </li>
-        <li class="nav-item active">
+        <li class="nav-item">
+          <a class="nav-link" href="teams.html">MANAGE TEAMS</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="index.html">LOGIN</a>
         </li>
       </ul>

--- a/manager_dashboard/manager_dashboard/index.html
+++ b/manager_dashboard/manager_dashboard/index.html
@@ -60,11 +60,14 @@
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav mr-auto">
-        <li class="nav-item active">
+        <li class="nav-item">
           <a class="nav-link" href="create.html">CREATE PROJECTS</a>
         </li>
-        <li class="nav-item active">
+        <li class="nav-item">
           <a class="nav-link" href="manage.html">MANAGE PROJECTS</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="teams.html">MANAGE TEAMS</a>
         </li>
         <li class="nav-item active">
           <a class="nav-link" href="index.html">LOGIN</a>

--- a/manager_dashboard/manager_dashboard/js/forms.js
+++ b/manager_dashboard/manager_dashboard/js/forms.js
@@ -6,6 +6,7 @@ function adjust_textarea(h) {
 
 function initForm() {
     initMap();
+    initTeams();
     displayProjectTypeForm("build_area")
 }
 
@@ -21,6 +22,25 @@ function initMap() {
   setTimeout(function(){ ProjectAoiMap.invalidateSize()}, 400);
 
   }
+
+
+function initTeams() {
+    console.log("init teams")
+    // get teams from firebase
+    var TeamsRef = firebase.database().ref("v2/teams").orderByChild("teamName");
+    TeamsRef.once('value', function(snapshot){
+    if(snapshot.exists()){
+        snapshot.forEach(function(data){
+            // add teamName to drop down option and set teamId as value
+            option = document.createElement('option')
+            option.innerHTML = data.val().teamName
+            option.value = data.key
+            document.getElementById("visibility").appendChild(option);
+            })
+        }
+    })
+}
+
 
 function displayProjectTypeForm(projectType) {
     document.getElementById("projectType").value = projectType;

--- a/manager_dashboard/manager_dashboard/js/project-management.js
+++ b/manager_dashboard/manager_dashboard/js/project-management.js
@@ -21,6 +21,27 @@ function getTeams() {
 
 
 function getProjects(status) {
+  // init basic structure
+  switch (status) {
+    case "active":
+    case "private_active":
+         var tableRef = $("#projectsTable-active").DataTable();
+         break;
+    case "inactive":
+    case "private_inactive":
+         var tableRef = $("#projectsTable-inactive").DataTable();
+         break;
+    case "finished":
+    case "private_finished":
+         var tableRef = $("#projectsTable-finished").DataTable();
+         break;
+    case "archived":
+         var tableRef = $("#projectsTable-archived").DataTable();
+         break;
+  }
+
+  var rows = []
+
   console.log('start download projects from firebase')
   var teams = getTeams()
   var projects =  []
@@ -30,9 +51,9 @@ function getProjects(status) {
         snapshot.forEach(function(data){
             info = {
                     "projectId": data.key,
-                    "name": data.val().name,
-                    "projectType": data.val().projectType,
-                    "progress": data.val().progress
+                    "name": data.val().name || "undefined",
+                    "projectType": data.val().projectType || 1,
+                    "progress": data.val().progress || 0
                     }
 
             // set visibility based on status
@@ -40,162 +61,101 @@ function getProjects(status) {
                 case "active":
                 case "inactive":
                 case "finished":
+                case "archived":
                     info["visibility"] = "public";
                     break;
                 case "private_active":
                 case "private_inactive":
                 case "private_finished":
+                case "private_archived":
                     info["visibility"] = teams[data.val().teamId]["teamName"];
                     break;
             }
-            projects.push(info)
-        })
-    }
-  })
-
-  return projects
-}
-
-
-function addProjectToTable(status){
-    // init basic structure
-    var tableRef = $("#projectsTable-"+status).DataTable();
-    var rows = []
-
-    // get projects based on status
-    switch (status) {
-        case "active":
-            // get active and private_active projects
-            public_projects = getProjects("active")
-            private_projects = getProjects("private_active")
-            merged_projects = {public_projects, private_projects};
-            break;
-        case "inactive":
-            // get inactive and private inactive projects
-            public_projects = getProjects("inactive")
-            private_projects = getProjects("private_inactive")
-            break;
-        case "finished":
-            // get finished and private finished projects
-            public_projects = getProjects("finished")
-            private_projects = getProjects("private_finished")
-            merged_projects = {public_projects, private_projects};
-            break;
-        case "archived":
-            // for archived projects we do not distinguish public or private
-            public_projects = getProjects("archived")
-            private_projects = {}
-            break;
-    }
-
-    console.log(public_projects)
-    console.log(public_projects.length)
-
-    for (var i = 0; i < public_projects.length; i++) {
-        console.log(public_projects[i]);
-        //Do something
-        console.log('hey')
-    }
-
-
-
-
-}
-
-
-    /*
-
-
-    $('.dataTables_length').addClass('bs-select');
-    console.log('added data table styles')
-
-
-            /*
-                })
-            projectId = data.key
-            var projectStatus = data.val().status
 
             row_array = []
-            row_array.push(projectId)
-            row_array.push(data.val().name)  // set project name
-            row_array.push("Public")  // set visibility
-            row_array.push(data.val().projectType)  // set project type
-            row_array.push(data.val().progress + "%")  // set project progress
+            row_array.push(info["projectId"])
+            row_array.push(info["name"])  // set project name
+            row_array.push(info["visibility"])  // set visibility
+            row_array.push(info["projectType"])  // set project type
+            row_array.push(info["progress"] + "%")  // set project progress
 
-            // set visibility based on status
-            switch (projectStatus) {
+            // set extra columns based on status
+            switch (status) {
                 case "active":
-                case "inactive":
-                case "finished":
-                    visibility = "public";
-                    console.log("public");
+                    btn1 = addButton(data.key, data.val().status, "inactive")
+                    btn2 = addButton(data.key, data.val().status, "finished")
+                    row_array.push(btn1.outerHTML + btn2.outerHTML)
+                    btn = document.createElement('button')
+                    btn.id = data.key
+                    btn.classList.add("btn")
+                    btn.classList.add("btn-warning")
+                    btn.classList.add("change-isFeatured")
+                    btn.classList.add("isFeatured-"+data.val().isFeatured)
+                    if (data.val().isFeatured === true) {
+                      btn.innerHTML = 'set to "false"'
+                      row_val = "<b>"+data.val().isFeatured+"</b>"
+                      row_array.push(row_val + "<br>" + btn.outerHTML)
+                    } else if (data.val().isFeatured === false) {
+                      btn.innerHTML = 'set to "true"'
+                      row_val = data.val().isFeatured
+                      row_array.push(row_val + "<br>" + btn.outerHTML)
+                    }
+                    row_array.push(row_val + btn.outerHTML)
                     break;
                 case "private_active":
+                    btn1 = addButton(data.key, data.val().status, "private_inactive")
+                    btn2 = addButton(data.key, data.val().status, "private_finished")
+                    row_array.push(btn1.outerHTML + btn2.outerHTML)
+                    btn = document.createElement('button')
+                    btn.id = data.key
+                    btn.classList.add("btn")
+                    btn.classList.add("btn-warning")
+                    btn.classList.add("change-isFeatured")
+                    btn.classList.add("isFeatured-"+data.val().isFeatured)
+                    if (data.val().isFeatured === true) {
+                      btn.innerHTML = 'set to "false"'
+                      row_val = "<b>"+data.val().isFeatured+"</b>"
+                      row_array.push(row_val + "<br>" + btn.outerHTML)
+                    } else if (data.val().isFeatured === false) {
+                      btn.innerHTML = 'set to "true"'
+                      row_val = data.val().isFeatured
+                      row_array.push(row_val + "<br>" + btn.outerHTML)
+                    }
+                    row_array.push(row_val + btn.outerHTML)
+                    break;
+                    break;
+                case "inactive":
+                    btn1 = addButton(data.key, data.val().status, "active")
+                    btn2 = addButton(data.key, data.val().status, "finished")
+                    row_array.push(btn1.outerHTML + btn2.outerHTML)
+                    break;
                 case "private_inactive":
+                    btn1 = addButton(data.key, data.val().status, "private_active")
+                    btn2 = addButton(data.key, data.val().status, "private_finished")
+                    row_array.push(btn1.outerHTML + btn2.outerHTML)
+                    break;
+                case "finished":
+                    btn = addButton(data.key, data.val().status, "inactive")
+                    row_array.push(btn.outerHTML)
+                    break
                 case "private_finished":
-                    console.log(teams)
-                    //console.log(data.val().teamId)
-                    //console.log(data.val())
-                    //visibility = teams[data.val().teamId]["teamName"]
+                    btn = addButton(data.key, data.val().status, "private_inactive")
+                    row_array.push(btn.outerHTML)
+                    break;
             }
-
-            if (data.val().status == "inactive") {
-              btn1 = addButton(data.key, data.val().status, "active")
-              btn2 = addButton(data.key, data.val().status, "finished")
-              row_array.push(btn1.outerHTML + btn2.outerHTML)
-            } else if (data.val().status == "active") {
-              btn1 = addButton(data.key, data.val().status, "inactive")
-              btn2 = addButton(data.key, data.val().status, "finished")
-              row_array.push(btn1.outerHTML + btn2.outerHTML)
-            } else if (data.val().status == "finished") {
-              btn = addButton(data.key, data.val().status, "inactive")
-              row_array.push(btn.outerHTML)
-            }
-
-            if (data.val().status == "active"){
-
-                btn = document.createElement('button')
-                btn.id = data.key
-                btn.classList.add("btn")
-                btn.classList.add("btn-warning")
-                btn.classList.add("change-isFeatured")
-                btn.classList.add("isFeatured-"+data.val().isFeatured)
-
-                if (data.val().isFeatured === true) {
-                  btn.innerHTML = 'set to "false"'
-                  row_val = "<b>"+data.val().isFeatured+"</b>"
-                  row_array.push(row_val + "<br>" + btn.outerHTML)
-                } else if (data.val().isFeatured === false) {
-                  btn.innerHTML = 'set to "true"'
-                  row_val = data.val().isFeatured
-                  row_array.push(row_val + "<br>" + btn.outerHTML)
-                }
-
-                row_array.push(row_val + btn.outerHTML)
-            }
-
 
 
             rows.push(row_array)
             tableRef.row.add(row_array).draw( false )
-        });
-    };
-    $('.dataTables_length').addClass('bs-select');
-    console.log('added data table styles')
-  });
-  */
+            //projects.push(info)
+        })
+    }
+  })
+  $('.dataTables_length').addClass('bs-select');
+  console.log('added data table styles')
 
+}
 
-/*
-function addProjectToTable(status):
-    var tableRef = $("#projectsTable-"+status).DataTable();
-    var rows = []
-
-
-    $('.dataTables_length').addClass('bs-select');
-    console.log('added data table styles')
-
-*/
 
 function addButton(id, oldStatus, newStatus){
   btn = document.createElement('button')
@@ -226,7 +186,15 @@ function updateIsFeatured(projectId, newStatus) {
 }
 
 function updateTableView() {
-  status_array = ["active", "inactive", "finished", "archived"]
+    status_array = [
+        "active",
+        "private_active",
+        "inactive",
+        "private_inactive",
+        "finished",
+        "private_finished",
+        "archived"
+    ]
 
   for (var i = 0; i < status_array.length; i++) {
     status = status_array[i]
@@ -236,12 +204,8 @@ function updateTableView() {
         .rows()
         .remove()
         .draw();
+    getProjects(status)
     }
-
-    getProjects("active")
-    getProjects("inactive")
-    getProjects("finished")
-    getProjects("archived")
 
   console.log('updated table view')
 }
@@ -249,6 +213,7 @@ function updateTableView() {
 
 function changeProjectStatus() {
   console.log('project selected: ' + this.id)
+
 
   if (this.classList.contains("new-status-active")){
     updateStatus(this.id, "active")
@@ -259,7 +224,17 @@ function changeProjectStatus() {
   } else if (this.classList.contains("new-status-finished")) {
     updateStatus(this.id, "finished")
     console.log("new status: finished")
+  } else if (this.classList.contains("new-status-private_active")) {
+    updateStatus(this.id, "private_active")
+    console.log("new status: private_active")
+  } else if (this.classList.contains("new-status-private_inactive")) {
+    updateStatus(this.id, "private_inactive")
+    console.log("new status: private_inactive")
+  } else if (this.classList.contains("new-status-private_finished")) {
+    updateStatus(this.id, "private_finished")
+    console.log("new status: private_finished")
   }
+
   updateTableView()
 }
 
@@ -279,13 +254,19 @@ function changeProjectIsFeatured() {
 }
 
 
-status_array = ["active", "inactive", "finished", "archived"]
-status_array = ["inactive"]
+status_array = [
+    "active",
+    "private_active",
+    "inactive",
+    "private_inactive",
+    "finished",
+    "private_finished",
+    "archived"
+]
 
-  for (var i = 0; i < status_array.length; i++) {
-    status = status_array[i]
+for (var i = 0; i < status_array.length; i++) {
+status = status_array[i]
 
-    addProjectToTable(status)
-    //getProjects(status)
-    addEventListeners(status)
-  }
+getProjects(status)
+addEventListeners(status)
+}

--- a/manager_dashboard/manager_dashboard/js/project-management.js
+++ b/manager_dashboard/manager_dashboard/js/project-management.js
@@ -147,7 +147,6 @@ function getProjects(status) {
 
             rows.push(row_array)
             tableRef.row.add(row_array).draw( false )
-            //projects.push(info)
         })
     }
   })

--- a/manager_dashboard/manager_dashboard/js/team-management.js
+++ b/manager_dashboard/manager_dashboard/js/team-management.js
@@ -1,0 +1,67 @@
+function addEventListenersTeams() {
+  $("#teamsTable").on('click', '.get-team-members', getTeamMembers);
+}
+
+
+function addTeamsToTable() {
+
+    var tableRef = $("#teamsTable").DataTable();
+    var rows = []
+
+    var TeamsRef = firebase.database().ref("v2/teams");
+    TeamsRef.once('value', function(snapshot){
+        if(snapshot.exists()){
+            snapshot.forEach(function(data){
+                row_array = []
+                row_array.push(data.key)
+                row_array.push(data.val().teamName)
+                row_array.push(data.val().teamToken)
+                // add button for team members
+                btn = document.createElement('button')
+                btn.id = data.key
+                btn.classList.add("btn")
+                btn.classList.add("btn-warning")
+                btn.classList.add("get-team-members")
+                btn.innerHTML = 'getTeamMembers()'
+                row_array.push(btn.outerHTML)
+                rows.push(row_array)
+                tableRef.row.add(row_array).draw( false )
+                })
+            }
+        })
+    $('.dataTables_length').addClass('bs-select');
+    console.log('added data table styles')
+    console.log("got teams from firebase")
+}
+
+
+function getTeamMembers() {
+    console.log('team selected: ' + this.id)
+    var teamId = this.id
+
+    var tableRef = $("#teamMembersTable").DataTable();
+    var rows = []
+
+    var TeamsRef = firebase.database().ref("v2/users").orderByChild("teamId").equalTo(teamId);;
+    TeamsRef.once('value', function(snapshot){
+        if(snapshot.exists()){
+            snapshot.forEach(function(data){
+                row_array = []
+                row_array.push(data.key)
+                row_array.push(data.val().username)
+                row_array.push(data.val().projectContributionCount)
+                row_array.push(data.val().groupContributionCount)
+                row_array.push(data.val().taskContributionCount)
+                rows.push(row_array)
+                tableRef.row.add(row_array).draw( false )
+                })
+            }
+        })
+    $('.dataTables_length').addClass('bs-select');
+    console.log('added data table styles')
+    console.log("got teams from firebase")
+}
+
+
+addTeamsToTable();
+addEventListenersTeams()

--- a/manager_dashboard/manager_dashboard/js/team-management.js
+++ b/manager_dashboard/manager_dashboard/js/team-management.js
@@ -40,6 +40,8 @@ function getTeamMembers() {
     var teamId = this.id
 
     var tableRef = $("#teamMembersTable").DataTable();
+    // remove all existing rows
+    tableRef.clear();
     var rows = []
 
     var TeamsRef = firebase.database().ref("v2/users").orderByChild("teamId").equalTo(teamId);;

--- a/manager_dashboard/manager_dashboard/js/team-management.js
+++ b/manager_dashboard/manager_dashboard/js/team-management.js
@@ -51,9 +51,9 @@ function getTeamMembers() {
                 row_array = []
                 row_array.push(data.key)
                 row_array.push(data.val().username)
-                row_array.push(data.val().projectContributionCount)
-                row_array.push(data.val().groupContributionCount)
-                row_array.push(data.val().taskContributionCount)
+                row_array.push(data.val().projectContributionCount || 0)
+                row_array.push(data.val().groupContributionCount || 0)
+                row_array.push(data.val().taskContributionCount || 0)
                 rows.push(row_array)
                 tableRef.row.add(row_array).draw( false )
                 })

--- a/manager_dashboard/manager_dashboard/js/uploadProjects.js
+++ b/manager_dashboard/manager_dashboard/js/uploadProjects.js
@@ -19,6 +19,12 @@ function getFormInput() {
         ' (' + form_data.projectNumber + ')\n' +
         form_data.requestingOrganisation
 
+    // add teamId if visibility is not set to public
+    visibility = document.getElementById("visibility").value
+    if (visibility != "public") {
+        form_data.teamId = visibility
+    }
+
     // add project type specific attributes
     projectType = document.getElementById("projectType").value
     switch (projectType) {

--- a/manager_dashboard/manager_dashboard/manage.html
+++ b/manager_dashboard/manager_dashboard/manage.html
@@ -99,6 +99,7 @@
                     <tr class="thead-inverse">
                       <th>Project ID</th>
                       <th>Name</th>
+                      <th>Visibility</th>
                       <th>Project Type</th>
                       <th>Progress</th>
                       <th>Change Status</th>
@@ -118,6 +119,7 @@
                         <tr class="thead-inverse">
                           <th>Project ID</th>
                           <th>Name</th>
+                          <th>Visibility</th>
                           <th>Project Type</th>
                           <th>Progress</th>
                           <th>Change Status</th>
@@ -136,6 +138,7 @@
                         <tr class="thead-inverse">
                           <th>Project ID</th>
                           <th>Name</th>
+                          <th>Visibility</th>
                           <th>Project Type</th>
                           <th>Progress</th>
                           <th>Change Status</th>

--- a/manager_dashboard/manager_dashboard/manage.html
+++ b/manager_dashboard/manager_dashboard/manage.html
@@ -157,6 +157,7 @@
                         <tr class="thead-inverse">
                           <th>Project ID</th>
                           <th>Name</th>
+                          <th>Visibility</th>
                           <th>Project Type</th>
                           <th>Progress</th>
                         </tr>

--- a/manager_dashboard/manager_dashboard/manage.html
+++ b/manager_dashboard/manager_dashboard/manage.html
@@ -60,13 +60,16 @@
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav mr-auto">
-        <li class="nav-item active">
+        <li class="nav-item">
           <a class="nav-link" href="create.html">CREATE PROJECTS</a>
         </li>
         <li class="nav-item active">
           <a class="nav-link" href="manage.html">MANAGE PROJECTS</a>
         </li>
-        <li class="nav-item active">
+        <li class="nav-item">
+          <a class="nav-link" href="teams.html">MANAGE TEAMS</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="index.html">LOGIN</a>
         </li>
       </ul>

--- a/manager_dashboard/manager_dashboard/teams.html
+++ b/manager_dashboard/manager_dashboard/teams.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<!-- This site was created in Webflow. http://www.webflow.com-->
+<!-- Last Published: Wed Jul 13 2016 22:45:08 GMT+0000 (UTC) -->
+<html data-wf-site="574807d20d1625555c1ee150" data-wf-page="577fcec769b57ef60a37539a">
+<head>
+    <meta charset="utf-8">
+    <title>Team Management | MapSwipe</title>
+    <meta name="description"
+          content="Humanitarian organisations can&#39;t help people if they can&#39;t find them. MapSwipe is a mobile app that lets you search satellite imagery to help put the world&#39;s most vulnerable people on the map.">
+    <meta property="og:title" content="Add Project | MapSwipe">
+    <meta property="og:description"
+          content="Humanitarian organisations can&#39;t help people if they can&#39;t find them. MapSwipe is a mobile app that lets you search satellite imagery to help put the world&#39;s most vulnerable people on the map.">
+    <meta property="og:image" content="http://mapswipe.org/images/og-img.jpg">
+    <meta name="twitter:card" content="summary">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- add firebase -->
+    <script src="https://cdn.firebase.com/libs/firebaseui/4.0.0/firebaseui.js"></script>
+    <link type="text/css" rel="stylesheet" href="https://cdn.firebase.com/libs/firebaseui/4.0.0/firebaseui.css" />
+
+    <!-- add jquery, ajax -->
+    <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+
+    <!-- Add Bootstrap -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+
+    <!-- Add Data Tables -->
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.20/css/dataTables.bootstrap.min.css">
+    <script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
+
+    <!-- add mapswipe styles -->
+    <link type="text/css" rel="stylesheet" href="css/mapswipe.css" />
+
+    <!-- add leaflet and turf.js -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"  integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="  crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js" integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og==" crossorigin=""></script>
+    <script src="https://cdn.jsdelivr.net/npm/@turf/turf@5/turf.min.js"></script>
+
+    <!-- add sentry -->
+    <script
+      src="https://browser.sentry-cdn.com/5.7.1/bundle.min.js"
+      integrity="sha384-KMv6bBTABABhv0NI+rVWly6PIRvdippFEgjpKyxUcpEmDWZTkDOiueL5xW+cztZZ"
+      crossorigin="anonymous"></script>
+    <script>
+        Sentry.init({ dsn: 'https://30340378d1e5495ca7c4d7c8751f0cba@sentry.io/1788403' });
+    </script>
+
+</head>
+<body>
+
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <a class="navbar-brand" href="index.html">
+      <img src="images/mapswipe-logo.svg" height="40"  alt="">
+    </a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav mr-auto">
+        <li class="nav-item">
+          <a class="nav-link" href="create.html">CREATE PROJECTS</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="manage.html">MANAGE PROJECTS</a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="teams.html">MANAGE TEAMS</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="index.html">LOGIN</a>
+        </li>
+      </ul>
+      <form class="form-inline my-2 my-lg-0">
+        <button id="sign-out" class="btn btn-primary" style="display: none">Log Out</button>
+      </form>
+    </div>
+  </nav>
+
+  <div id="not-signed-in" class="container">
+    <div class="row justify-content-center">
+      <h3>Please <a href="index.html">log in</a> first.</h3>
+    </div>
+  </div>
+
+  <div class="section" id="not-signed-in">
+    <div id="firebaseui-auth-container"></div>
+  </div>
+
+  <div class="section" id="signed-in-manager" style="display: none">
+      <div class="container" >
+
+        <!-- manage existing projects -->
+        <div class="row justify-content-center" id="project-management" style="display: block">
+            <div id="teams" class="col-md-12 project-data">
+                <h2>Teams</h2>
+                <p>These teams are currently set up in the MapSwipe app.</p>
+                <table id="teamsTable" class="table table-striped table-bordered">
+                  <thead>
+                    <tr class="thead-inverse">
+                      <th>Team ID</th>
+                      <th>Name</th>
+                      <th>Token</th>
+                      <th>Members</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <!-- will be added by function -->
+                  </tbody>
+                </table>
+                <!-- Team Members -->
+                <h2>Team Members</h2>
+                <p>Click the button for one of the teams above to display team members. (Note: this shows all contributions and thus might also contain contributions to non-private projects.</p>
+                <table id="teamMembersTable" class="table table-striped table-bordered">
+                  <thead>
+                    <tr class="thead-inverse">
+                      <th>User ID</th>
+                      <th>User Name</th>
+                      <th>Project Contributions</th>
+                      <th>Group Contributions</th>
+                      <th>Task Contributions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <!-- will be added by function -->
+                  </tbody>
+                </table>
+
+            </div>
+          </div>
+        </div>
+      </div>
+  </div>
+
+  <footer class="footer">
+    <div class="container" align="center">
+      <span class="text-muted">Copyright © 2019 MapSwipe</span>
+    </div>
+  </footer>
+
+<!-- <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script> -->
+<script src="https://www.gstatic.com/firebasejs/6.2.4/firebase-app.js"></script>
+<script src="https://www.gstatic.com/firebasejs/6.2.4/firebase-auth.js"></script>
+<script src="https://www.gstatic.com/firebasejs/6.2.4/firebase-firestore.js"></script>
+<script src="https://www.gstatic.com/firebasejs/6.2.4/firebase-database.js"></script>
+<script async defer src="js/app.js"></script>
+<script async defer src="js/ui.js"></script>
+<script async defer src="js/team-management.js"></script>
+
+</body>
+</html>

--- a/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
+++ b/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
@@ -135,24 +135,37 @@ def run_generate_stats_all_projects() -> None:
 
 @cli.command("user-management")
 @click.option(
-    "--email", help=(f"The email of the MapSwipe user."), required=True, type=str
+    "--email", help=f"The email of the MapSwipe user.", required=True, type=str
 )
+@click.option("--team_id", "-i", help=f"The id of the team in Firebase.", type=str)
 @click.option(
-    "--manager",
-    help=("Use true to grant credentials. Use false to remove credentials."),
-    type=bool,
+    "--action",
+    "-a",
+    help=(
+        f"You can either create, delete teams or renew the teamToken. " f"choices here"
+    ),
+    type=click.Choice(
+        ["add-manager-rights", "remove-manager-right", "add-team", "remove-team"]
+    ),
 )
-def run_user_management(email, manager) -> None:
+def run_user_management(email, action, team_id) -> None:
     """
     Manage project manager credentials
 
     Grant or remove credentials.
     """
     try:
-        if manager:
+        if action == "add-manager-rights":
             user_management.set_project_manager_rights(email)
-        elif not manager:
+        elif action == "remove-manager-rights":
             user_management.remove_project_manager_rights(email)
+        elif action == "add-team":
+            if not team_id:
+                click.echo("Missing argument: --team_id")
+                return None
+            user_management.add_team(email, team_id)
+        elif action == "remove-team":
+            user_management.remove_team(email)
     except Exception:
         logger.exception("grant user credentials failed")
         sentry.capture_exception()

--- a/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
+++ b/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
@@ -185,7 +185,9 @@ def run_user_management(email, action, team_id) -> None:
     help=(
         f"You can either create, delete teams or renew the teamToken. " f"choices here"
     ),
-    type=click.Choice(["create", "delete", "renew-team-token"]),
+    type=click.Choice(
+        ["create", "delete", "renew-team-token", "remove-all-team-members"]
+    ),
 )
 def run_team_management(team_name, team_id, action) -> None:
     """Create, Delete Teams or Renew TeamToken."""
@@ -220,6 +222,25 @@ def run_team_management(team_name, team_id, action) -> None:
                 return None
             else:
                 team_management.renew_team_token(team_id)
+        elif action == "remove-all-team-members":
+            if not team_id:
+                click.echo("Missing argument: --team_id")
+                return None
+            else:
+                click.echo(
+                    f"Do you want to remove all users from "
+                    f"the team with the id: {team_id}? [y/n] ",
+                    nl=False,
+                )
+                click.echo()
+                c = click.getchar()
+                if c == "y":
+                    click.echo("Start remove all team members")
+                    team_management.remove_all_team_members(team_id)
+                elif c == "n":
+                    click.echo("Abort!")
+                else:
+                    click.echo("Invalid input")
     except Exception:
         logger.exception("team management failed")
         sentry.capture_exception()

--- a/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
+++ b/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
@@ -165,9 +165,9 @@ def run_user_management(email, action, team_id) -> None:
             if not team_id:
                 click.echo("Missing argument: --team_id")
                 return None
-            user_management.add_team(email, team_id)
+            user_management.add_user_to_team(email, team_id)
         elif action == "remove-team":
-            user_management.remove_team(email)
+            user_management.remove_user_from_team(email)
     except Exception:
         logger.exception("grant user credentials failed")
         sentry.capture_exception()

--- a/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
+++ b/mapswipe_workers/mapswipe_workers/mapswipe_workers.py
@@ -142,7 +142,9 @@ def run_generate_stats_all_projects() -> None:
     "--action",
     "-a",
     help=(
-        f"You can either create, delete teams or renew the teamToken. " f"choices here"
+        f"You can either add, remove manager-rights or "
+        f"add, remove user to/from a team. "
+        f"choices here"
     ),
     type=click.Choice(
         ["add-manager-rights", "remove-manager-right", "add-team", "remove-team"]

--- a/mapswipe_workers/mapswipe_workers/project_types/base/project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/base/project.py
@@ -75,7 +75,7 @@ class BaseProject(metaclass=ABCMeta):
             self.status = "inactive"  # this is a public project
         else:
             self.status = (
-                "privat_inactive"  # private project visible only for team members
+                "private_inactive"  # private project visible only for team members
             )
 
     # TODO: Implement resultRequiredCounter as property.

--- a/mapswipe_workers/mapswipe_workers/project_types/base/project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/base/project.py
@@ -66,11 +66,17 @@ class BaseProject(metaclass=ABCMeta):
         self.projectId = project_draft["projectDraftId"]
         self.projectType = int(project_draft["projectType"])
         self.verificationNumber = project_draft["verificationNumber"]
-        self.status = "inactive"
         self.projectTopic = project_draft.get("projectTopic", None)
         self.projectRegion = project_draft.get("projectRegion", None)
         self.projectNumber = project_draft.get("projectNumber", None)
         self.requestingOrganisation = project_draft.get("requestingOrganisation", None)
+        self.teamId = project_draft.get("teamId", None)
+        if not self.teamId:
+            self.status = "inactive"  # this is a public project
+        else:
+            self.status = (
+                "privat_inactive"  # private project visible only for team members
+            )
 
     # TODO: Implement resultRequiredCounter as property.
     # Does not work because for some reason project['group'] = vars()

--- a/mapswipe_workers/mapswipe_workers/utils/team_management.py
+++ b/mapswipe_workers/mapswipe_workers/utils/team_management.py
@@ -1,0 +1,82 @@
+import uuid
+import re
+from mapswipe_workers.auth import firebaseDB
+from mapswipe_workers.definitions import logger, CustomError
+
+
+def create_team(team_name):
+    """Create new team in Firebase."""
+    fb_db = firebaseDB()  # noqa E841
+    try:
+        # generate random uuid4 token
+        team_token = str(uuid.uuid4())
+
+        # set data in firebase
+        ref = fb_db.reference(f"v2/teams/")
+        team_ref = ref.push()
+        team_ref.set({"teamName": team_name, "teamToken": team_token})
+        logger.info(f"created team: {team_ref.key} - '{team_name}' - {team_token}")
+    except Exception as e:
+        logger.info(f"could not create team: {team_name}")
+        raise CustomError(e)
+
+
+def delete_team(team_id):
+    """Delete team in Firebase."""
+    # TODO: What is the consequence of this on projects and users
+    #   do we expect that the teamId is removed there as well?
+    fb_db = firebaseDB()  # noqa E841
+    try:
+        # check if team exist in firebase
+        if not fb_db.reference(f"v2/teams/{team_id}").get():
+            raise CustomError(f"can't find team in firebase: {team_id}")
+
+        # get team name from firebase
+        team_name = fb_db.reference(f"v2/teams/{team_id}/teamName").get()
+
+        # check if reference path is valid, e.g. if team_id is None
+        ref = fb_db.reference(f"v2/teams/{team_id}")
+        if not re.match(r"/v2/\w+/[-a-zA-Z0-9]+", ref.path):
+            raise CustomError(
+                f"""Given argument resulted in invalid Firebase Realtime Database reference.
+                        {ref.path}"""
+            )
+
+        # delete team in firebase
+        ref.delete()
+        logger.info(f"deleted team: {team_id} - '{team_name}'")
+
+    except Exception as e:
+        logger.info(f"could not delete team: {team_id}")
+        raise CustomError(e)
+
+
+def renew_team_token(team_id):
+    """Create new team in Firebase."""
+    fb_db = firebaseDB()  # noqa E841
+    try:
+        # check if team exist in firebase
+        if not fb_db.reference(f"v2/teams/{team_id}").get():
+            raise CustomError(f"can't find team in firebase: {team_id}")
+
+        # get team name from firebase
+        team_name = fb_db.reference(f"v2/teams/{team_id}/teamName").get()
+
+        # check if reference path is valid
+        ref = fb_db.reference(f"v2/teams/{team_id}")
+        if not re.match(r"/v2/\w+/[-a-zA-Z0-9]+", ref.path):
+            raise CustomError(
+                f"""Given argument resulted in invalid Firebase Realtime Database reference.
+                        {ref.path}"""
+            )
+
+        # generate new uuid4 token
+        new_team_token = str(uuid.uuid4())
+
+        # set team token in firebase
+        ref.update({"teamToken": new_team_token})
+        logger.info(f"renewed team token: {team_id} - '{team_name}' - {new_team_token}")
+
+    except Exception as e:
+        logger.info(f"could not delete team: {team_id}")
+        raise CustomError(e)

--- a/mapswipe_workers/mapswipe_workers/utils/team_management.py
+++ b/mapswipe_workers/mapswipe_workers/utils/team_management.py
@@ -54,6 +54,7 @@ def create_team(team_name):
         team_ref = ref.push()
         team_ref.set({"teamName": team_name, "teamToken": team_token})
         logger.info(f"created team: {team_ref.key} - '{team_name}' - {team_token}")
+        return team_ref.key, team_token
     except Exception as e:
         logger.info(f"could not create team: {team_name}")
         raise CustomError(e)
@@ -118,6 +119,7 @@ def renew_team_token(team_id):
         # set team token in firebase
         ref.update({"teamToken": new_team_token})
         logger.info(f"renewed team token: {team_id} - '{team_name}' - {new_team_token}")
+        return new_team_token
 
     except Exception as e:
         logger.info(f"could not delete team: {team_id}")

--- a/mapswipe_workers/mapswipe_workers/utils/user_management.py
+++ b/mapswipe_workers/mapswipe_workers/utils/user_management.py
@@ -160,7 +160,7 @@ def permission_denied(request_object):
             raise HTTPError(e, request_object.text)
 
 
-def add_team(email, team_id):
+def add_user_to_team(email, team_id):
     """Add teamId attribute for user."""
     try:
         fb_db = firebaseDB()  # noqa E841
@@ -185,7 +185,7 @@ def add_team(email, team_id):
         raise CustomError(e)
 
 
-def remove_team(email):
+def remove_user_from_team(email):
     """Remove teamId attribute for user."""
     try:
         fb_db = firebaseDB()  # noqa E841
@@ -201,7 +201,7 @@ def remove_team(email):
 
         # remove teamId attribute for user in firebase
         ref = fb_db.reference(f"v2/users/{user.uid}")
-        ref.update({"teamId": None})
+        ref.update({"teamId": None})  # deletes the teamId attribute in firebase
         logger.info(f"removed teamId {team_id} for user {email} - {user.uid}.")
 
     except Exception as e:

--- a/mapswipe_workers/mapswipe_workers/utils/user_management.py
+++ b/mapswipe_workers/mapswipe_workers/utils/user_management.py
@@ -175,7 +175,7 @@ def add_team(email, team_id):
         except auth.UserNotFoundError:
             raise CustomError(f"can't find user in firebase: {email}")
 
-        # set team token in firebase
+        # set teamId attribute for user in firebase
         ref = fb_db.reference(f"v2/users/{user.uid}")
         ref.update({"teamId": team_id})
         logger.info(f"added teamId {team_id} for user {email} - {user.uid}.")

--- a/mapswipe_workers/mapswipe_workers/utils/user_management.py
+++ b/mapswipe_workers/mapswipe_workers/utils/user_management.py
@@ -158,3 +158,52 @@ def permission_denied(request_object):
             return True
         else:
             raise HTTPError(e, request_object.text)
+
+
+def add_team(email, team_id):
+    """Add teamId attribute for user."""
+    try:
+        fb_db = firebaseDB()  # noqa E841
+
+        # check if team exist in firebase
+        if not fb_db.reference(f"v2/teams/{team_id}").get():
+            raise CustomError(f"can't find team in firebase: {team_id}")
+
+        # get user by email
+        try:
+            user = auth.get_user_by_email(email)
+        except auth.UserNotFoundError:
+            raise CustomError(f"can't find user in firebase: {email}")
+
+        # set team token in firebase
+        ref = fb_db.reference(f"v2/users/{user.uid}")
+        ref.update({"teamId": team_id})
+        logger.info(f"added teamId {team_id} for user {email} - {user.uid}.")
+
+    except Exception as e:
+        logger.info(f"could not add teamId attribute for user.")
+        raise CustomError(e)
+
+
+def remove_team(email):
+    """Remove teamId attribute for user."""
+    try:
+        fb_db = firebaseDB()  # noqa E841
+
+        # get user by email
+        try:
+            user = auth.get_user_by_email(email)
+        except auth.UserNotFoundError:
+            raise CustomError(f"can't find user in firebase: {email}")
+
+        # get teamId from firebase
+        team_id = fb_db.reference(f"v2/users/{user.uid}/teamId").get()
+
+        # remove teamId attribute for user in firebase
+        ref = fb_db.reference(f"v2/users/{user.uid}")
+        ref.update({"teamId": None})
+        logger.info(f"removed teamId {team_id} for user {email} - {user.uid}.")
+
+    except Exception as e:
+        logger.info(f"could not remove teamId attribute for user.")
+        raise CustomError(e)

--- a/mapswipe_workers/tests/integration/test_firebase_db_rules.py
+++ b/mapswipe_workers/tests/integration/test_firebase_db_rules.py
@@ -1,0 +1,44 @@
+import unittest
+
+# import re
+
+# from mapswipe_workers.auth import firebaseDB
+# from mapswipe_workers.definitions import CustomError
+
+
+class TestFirebaseDBRules(unittest.TestCase):
+    def setUp(self):
+        # set up 4 users with specified roles
+        # normal app user
+
+        # team member
+
+        # project manager
+
+        # project manager and team member
+
+        pass
+
+    def tearDown(self):
+        # tear down up 4 users with specified roles
+        pass
+
+    def test_normal_user(self):
+        # read public projects
+
+        # read public groups
+
+        # read public tasks (still needed for tutorial)
+
+        # write to results based on user_id
+
+        pass
+
+    def test_team_member(self):
+        pass
+
+    def test_project_manager(self):
+        pass
+
+    def test_project_manager_and_team_member(self):
+        pass

--- a/mapswipe_workers/tests/integration/test_firebase_db_rules.py
+++ b/mapswipe_workers/tests/integration/test_firebase_db_rules.py
@@ -1,44 +1,271 @@
+import json
 import unittest
+from requests.exceptions import HTTPError
+import requests
+import re
+from mapswipe_workers.config import FIREBASE_DB, FIREBASE_API_KEY
+from mapswipe_workers.auth import firebaseDB
+from mapswipe_workers.definitions import logger, CustomError
+from mapswipe_workers.utils import user_management
 
-# import re
 
-# from mapswipe_workers.auth import firebaseDB
-# from mapswipe_workers.definitions import CustomError
+def set_up_team():
+    fb_db = firebaseDB()
+    team_id = "unittest-team-1234"
+    team_name = "unittest-team"
+    team_token = "12345678-1234-5678-1234-567812345678"
+    data = {"teamName": team_name, "teamToken": team_token}
+    ref = fb_db.reference(f"v2/teams/{team_id}")
+    ref.set(data)
+
+    return team_id, team_name, team_token
+
+
+def tear_down_team(team_id):
+    fb_db = firebaseDB()
+    # check if reference path is valid, e.g. if team_id is None
+    ref = fb_db.reference(f"v2/teams/{team_id}")
+    if not re.match(r"/v2/\w+/[-a-zA-Z0-9]+", ref.path):
+        raise CustomError(
+            f"""Given argument resulted in invalid Firebase Realtime Database reference.
+                                    {ref.path}"""
+        )
+
+    # delete team in firebase
+    ref.delete()
+
+
+def setup_user(project_manager: bool, team_member: bool, team_id=None):
+    if project_manager and team_member:
+        username = f"unittest-project-manager-and-team-member"
+    elif project_manager:
+        username = f"unittest-project-manager"
+    elif team_member:
+        username = f"unittest-team-member"
+    else:
+        username = f"unittest-normal-user"
+
+    email = f"{username}@mapswipe.org"
+    password = f"{username}_pw"
+
+    # username will be user.display_name
+    user = user_management.create_user(email, username, password)
+
+    # set project manager credentials
+
+    # set team member attribute
+    if team_member:
+        user_management.add_user_to_team(email, team_id)
+
+    return user
+
+
+def sign_in_with_email_and_password(email, password):
+    api_key = FIREBASE_API_KEY
+    request_ref = (
+        "https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword"
+        "?key={0}".format(api_key)
+    )
+    headers = {"content-type": "application/json; charset=UTF-8"}
+    data = json.dumps({"email": email, "password": password, "returnSecureToken": True})
+    request_object = requests.post(request_ref, headers=headers, data=data)
+    current_user = request_object.json()
+    logger.info(f"signed in with user {email}")
+    return current_user
+
+
+def permission_denied(request_object):
+    try:
+        request_object.raise_for_status()
+    except HTTPError as e:
+        if "Permission denied" in request_object.text:
+            return True
+        else:
+            raise HTTPError(e, request_object.text)
+
+
+def test_get_endpoint(user, path, custom_arguments=""):
+    database_url = f"https://{FIREBASE_DB}.firebaseio.com"
+    request_ref = f"{database_url}{path}.json?{custom_arguments}&auth={user['idToken']}"
+    headers = {"content-type": "application/json; charset=UTF-8"}
+    request_object = requests.get(request_ref, headers=headers)
+    if permission_denied(request_object):
+        logger.info(
+            f"permission denied for {database_url}{path}.json?{custom_arguments}"
+        )
+        return False
+    else:
+        logger.info(
+            f"permission granted for {database_url}{path}.json?{custom_arguments}"
+        )
+        return True
+
+
+def test_set_endpoint(user, endpoint):
+    pass
+
+
+def test_update_endpoint(user, endpoint):
+    pass
 
 
 class TestFirebaseDBRules(unittest.TestCase):
     def setUp(self):
-        # set up 4 users with specified roles
-        # normal app user
+        # setup team
+        self.team_id, self.team_name, self.team_token = set_up_team()
+        fb_db = firebaseDB()
+        ref = fb_db.reference(f"v2/teams/{self.team_id}")
+        ref.set({"teamName": "unittest-team", "teamToken": ""})
 
-        # team member
+        # setup public project
+        self.public_project_id = "unittest-public-project"
+        fb_db = firebaseDB()
+        ref = fb_db.reference(f"v2/projects/{self.public_project_id}")
+        ref.update({"status": "active"})
 
-        # project manager
+        # setup private project
+        self.private_project_id = "unittest-private-project"
+        fb_db = firebaseDB()
+        ref = fb_db.reference(f"v2/projects/{self.private_project_id}")
+        ref.update({"teamId": self.team_id, "status": "private_active"})
 
-        # project manager and team member
+        # setup users
+        self.normal_user = setup_user(project_manager=False, team_member=False)
+        self.team_member = setup_user(
+            project_manager=False, team_member=True, team_id=self.team_id
+        )
+        self.project_manager = setup_user(project_manager=True, team_member=False)
+        self.project_manager_and_team_member = setup_user(
+            project_manager=True, team_member=True, team_id=self.team_id
+        )
 
-        pass
+        # generate all endpoints to test
+        self.endpoints = [  # [path, custom_arguments]
+            # projects
+            [f"/v2/projects", f'orderBy="status"&equalTo="active"&limitToFirst=20'],
+            [f"/v2/projects/{self.public_project_id}/status", ""],
+            [
+                f"/v2/projects",
+                f'orderBy="teamId"&equalTo="{self.team_id}"&limitToFirst=20',
+            ],
+            [f"/v2/projects/{self.private_project_id}/status", ""],
+            # teams
+            [f"/v2/teams/{self.team_id}", ""],
+            [f"/v2/teams/{self.team_id}/teamName", ""],
+            [f"/v2/teams/{self.team_id}/teamToken", ""],
+            # groups
+            [f"/v2/groups/{self.public_project_id}", ""],
+            [f"/v2/groups/{self.private_project_id}", ""],
+            # tasks
+            [f"/v2/tasks/{self.public_project_id}", ""],
+            [f"/v2/tasks/{self.private_project_id}", ""],
+            # users
+            [f"/v2/users/<user_id>", ""],
+            [f"/v2/users/<user_id>/teamId", ""],
+            [f"/v2/users/<user_id>/username", ""],
+            # results
+            [f"/v2/results/{self.public_project_id}/<group_id>/<user_id>", ""],
+            [f"/v2/results/{self.private_project_id}/<group_id>/<user_id>", ""],
+        ]
 
     def tearDown(self):
-        # tear down up 4 users with specified roles
+        # tear down team
+        tear_down_team(self.team_id)
+
+        # tear down users
+        user_management.delete_user(self.normal_user.email)
+        user_management.delete_user(self.team_member.email)
+        user_management.delete_user(self.project_manager.email)
+        user_management.delete_user(self.project_manager_and_team_member.email)
+
+        # tear down public project
+
+        # tear down private project
+
+    def test_access_as_normal_user(self):
+        # sign in user with email and password to simulate app user
+        user = sign_in_with_email_and_password(
+            self.normal_user.email, f"{self.normal_user.display_name}_pw"
+        )
+
+        expected_access = [  # [read, write]
+            [True, False],  # public project query
+            [True, False],  # public project status attribute
+            [False, False],  # private project query
+            [False, False],  # private project status attribute
+            [False, False],  # team
+            [False, False],  # teamName
+            [False, False],  # teamToken
+            [True, False],  # public group
+            [False, False],  # private group
+            [True, False],  # public task
+            [False, False],  # private task
+            [True, False],  # user
+            [True, False],  # user teamId
+            [True, True],  # user username
+            [False, True],  # results public project
+            [False, False],  # results private project
+        ]
+
+        for i, endpoint in enumerate(self.endpoints):
+            path = endpoint[0].replace("<user_id>", user["localId"])
+            custom_arguments = endpoint[1]
+            access = test_get_endpoint(user, path, custom_arguments)
+            self.assertEqual(
+                access,
+                expected_access[i][0],
+                f"observed, expected, {endpoint} {user['displayName']}",
+            )
+
+    def test_access_as_team_member(self):
+        # sign in user with email and password to simulate app user
+        user = sign_in_with_email_and_password(
+            self.team_member.email, f"{self.team_member.display_name}_pw"
+        )
+
+        expected_access = [  # [read, write]
+            [True, False],  # public project query
+            [True, False],  # public project status attribute
+            [True, False],  # private project query
+            [True, False],  # private project status
+            [False, False],  # team
+            [True, False],  # teamName
+            [False, False],  # teamToken
+            [True, False],  # public group
+            [True, False],  # private group
+            [True, False],  # public task
+            [True, False],  # private task
+            [True, False],  # user
+            [True, False],  # user teamId
+            [True, True],  # user username
+            [False, True],  # results public project
+            [False, True],  # results private project
+        ]
+
+        for i, endpoint in enumerate(self.endpoints):
+            path = endpoint[0].replace("<user_id>", user["localId"])
+            custom_arguments = endpoint[1]
+            access = test_get_endpoint(user, path, custom_arguments)
+            self.assertEqual(
+                access,
+                expected_access[i][0],
+                f"observed, expected, {endpoint} {user['displayName']}",
+            )
+
+    """
+    def test_access_as_team_member(self):
+        user = self.team_member
         pass
 
-    def test_normal_user(self):
-        # read public projects
-
-        # read public groups
-
-        # read public tasks (still needed for tutorial)
-
-        # write to results based on user_id
-
+    def test_access_as_project_manager(self):
+        user = self.project_manager
         pass
 
-    def test_team_member(self):
+    def test_access_as_project_manager_and_team_member(self):
+        user = self.project_manager_and_team_member
         pass
+    """
 
-    def test_project_manager(self):
-        pass
 
-    def test_project_manager_and_team_member(self):
-        pass
+if __name__ == "__main__":
+    unittest.main()

--- a/mapswipe_workers/tests/integration/test_team_management.py
+++ b/mapswipe_workers/tests/integration/test_team_management.py
@@ -105,7 +105,7 @@ class TestTeamManagement(unittest.TestCase):
         self.assertGreaterEqual(len(new_team_token), 32)
         self.assertNotEqual(new_team_token, self.team_token)
 
-        # check if no data in Firebase
+        # check data in Firebase
         fb_db = firebaseDB()
         ref = fb_db.reference(f"v2/teams/{self.team_id}/teamToken")
         team_token = ref.get()

--- a/mapswipe_workers/tests/integration/test_team_management.py
+++ b/mapswipe_workers/tests/integration/test_team_management.py
@@ -1,0 +1,123 @@
+import unittest
+import re
+from mapswipe_workers.utils import team_management
+from mapswipe_workers.auth import firebaseDB
+from mapswipe_workers.definitions import CustomError
+
+
+def set_up_team():
+    fb_db = firebaseDB()
+    team_id = "unittest-team-1234"
+    team_name = "unittest-team"
+    team_token = "12345678-1234-5678-1234-567812345678"
+    data = {"teamName": team_name, "teamToken": team_token}
+    ref = fb_db.reference(f"v2/teams/{team_id}")
+    ref.set(data)
+
+    return team_id, team_name, team_token
+
+
+def set_up_team_member():
+    fb_db = firebaseDB()
+    team_id = "unittest-team-1234"
+    user_id = "unittest-team-member-1"
+    data = {"teamId": team_id}
+    ref = fb_db.reference(f"v2/users/{user_id}")
+    ref.set(data)
+
+    return user_id
+
+
+def tear_down_team(team_id):
+    fb_db = firebaseDB()
+    # check if reference path is valid, e.g. if team_id is None
+    ref = fb_db.reference(f"v2/teams/{team_id}")
+    if not re.match(r"/v2/\w+/[-a-zA-Z0-9]+", ref.path):
+        raise CustomError(
+            f"""Given argument resulted in invalid Firebase Realtime Database reference.
+                                    {ref.path}"""
+        )
+
+    # delete team in firebase
+    ref.delete()
+
+
+def tear_down_team_member(user_id):
+    fb_db = firebaseDB()
+    # check if reference path is valid, e.g. if team_id is None
+    ref = fb_db.reference(f"v2/users/{user_id}")
+    if not re.match(r"/v2/\w+/[-a-zA-Z0-9]+", ref.path):
+        raise CustomError(
+            f"""Given argument resulted in invalid Firebase Realtime Database reference.
+                                    {ref.path}"""
+        )
+
+    # delete team in firebase
+    ref.delete()
+
+
+class TestTeamManagement(unittest.TestCase):
+    def setUp(self):
+        self.team_id, self.team_name, self.team_token = set_up_team()
+        self.user_id = set_up_team_member()
+
+    def tearDown(self):
+        tear_down_team(self.team_id)
+        tear_down_team_member(self.user_id)
+
+    def test_create_team(self):
+        self.team_name = "unittest-team"
+        self.team_id, self.team_token = team_management.create_team(self.team_name)
+
+        # check if returned values are plausible
+        self.assertIsNotNone(self.team_id)
+        self.assertGreaterEqual(len(self.team_token), 32)
+
+        # check data in Firebase
+        fb_db = firebaseDB()
+        ref = fb_db.reference(f"v2/teams/{self.team_id}")
+        team_data = ref.get()
+        self.assertEqual(len(team_data), 2)
+        self.assertEqual(team_data["teamName"], self.team_name)
+        self.assertEqual(team_data["teamToken"], self.team_token)
+
+    def test_delete_team(self):
+        team_management.delete_team(self.team_id)
+
+        # check if no data in Firebase
+        fb_db = firebaseDB()
+        ref = fb_db.reference(f"v2/teams/{self.team_id}")
+        team_data = ref.get()
+        self.assertIsNone(team_data)
+
+        # check if no members
+        team_members = (
+            fb_db.reference(f"v2/users/")
+            .order_by_child("teamId")
+            .equal_to(self.team_id)
+            .get()
+        )
+        self.assertEqual(len(team_members), 0)
+
+    def test_renew_team_token(self):
+        new_team_token = team_management.renew_team_token(self.team_id)
+
+        self.assertGreaterEqual(len(new_team_token), 32)
+        self.assertNotEqual(new_team_token, self.team_token)
+
+    def test_remove_all_team_members(self):
+        team_management.remove_all_team_members(self.team_id)
+
+        # check if no members
+        fb_db = firebaseDB()
+        team_members = (
+            fb_db.reference(f"v2/users/")
+            .order_by_child("teamId")
+            .equal_to(self.team_id)
+            .get()
+        )
+        self.assertEqual(len(team_members), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mapswipe_workers/tests/integration/test_team_management.py
+++ b/mapswipe_workers/tests/integration/test_team_management.py
@@ -105,6 +105,12 @@ class TestTeamManagement(unittest.TestCase):
         self.assertGreaterEqual(len(new_team_token), 32)
         self.assertNotEqual(new_team_token, self.team_token)
 
+        # check if no data in Firebase
+        fb_db = firebaseDB()
+        ref = fb_db.reference(f"v2/teams/{self.team_id}/teamToken")
+        team_token = ref.get()
+        self.assertEqual(team_token, new_team_token)
+
     def test_remove_all_team_members(self):
         team_management.remove_all_team_members(self.team_id)
 


### PR DESCRIPTION
This sets the basic structure needed from MapSwipe back end side to allow for private projects. This refers to #392 

* adds functions to mapswipe_workers cli to set up new teams and manage which users are members
* extends manager dashboard to create and display private projects and to display teams including their members
* adjusts firebase database rules to account for new endpoint at `v2/teams`
* adjusts project creation workflow to set status of private projects to `private_inactive` once created

Team set up is currently handled only by mapswipe_workers cli. There you can also renew the `teamToken` attribute if needed.