### PR TITLE
compress files for export with gzip #451

### DIFF
--- a/mapswipe_workers/mapswipe_workers/generate_stats/project_stats.py
+++ b/mapswipe_workers/mapswipe_workers/generate_stats/project_stats.py
@@ -360,8 +360,7 @@ def get_per_project_statistics(project_id: str, project_info: pd.Series) -> dict
         agg_results_df = get_agg_results_by_task_id(results_df, tasks_df)
         agg_results_df.to_csv(
             agg_results_filename,
-            index_label="idx",
-            compression="gzip"
+            index_label="idx"
         )
 
         geojson_functions.gzipped_csv_to_gzipped_geojson(
@@ -379,8 +378,7 @@ def get_per_project_statistics(project_id: str, project_info: pd.Series) -> dict
             )
             agg_results_by_user_id_df.to_csv(
                 agg_results_by_user_id_filename,
-                index_label="idx",
-                compression="gzip"
+                index_label="idx"
             )
             logger.info(
                 f"saved agg results for {project_id}: {agg_results_by_user_id_filename}"

--- a/mapswipe_workers/mapswipe_workers/generate_stats/project_stats.py
+++ b/mapswipe_workers/mapswipe_workers/generate_stats/project_stats.py
@@ -378,7 +378,9 @@ def get_per_project_statistics(project_id: str, project_info: pd.Series) -> dict
                 results_df, agg_results_df
             )
             agg_results_by_user_id_df.to_csv(
-                agg_results_by_user_id_filename, index_label="idx"
+                agg_results_by_user_id_filename,
+                index_label="idx",
+                compression="gzip"
             )
             logger.info(
                 f"saved agg results for {project_id}: {agg_results_by_user_id_filename}"

--- a/mapswipe_workers/mapswipe_workers/generate_stats/tasking_manager_geometries.py
+++ b/mapswipe_workers/mapswipe_workers/generate_stats/tasking_manager_geometries.py
@@ -1,4 +1,5 @@
 import csv
+import gzip
 import threading
 from queue import Queue
 
@@ -8,7 +9,7 @@ from mapswipe_workers.definitions import DATA_PATH, logger
 from mapswipe_workers.utils import geojson_functions, tile_functions
 
 
-def load_data(project_id: str, csv_file: str) -> list:
+def load_data(project_id: str, gzipped_csv_file: str) -> list:
     """
     This will load the aggregated results csv file into a list of dictionaries.
     For further steps we currently rely on task_x, task_y, task_z and yes_share and
@@ -16,7 +17,7 @@ def load_data(project_id: str, csv_file: str) -> list:
     """
 
     project_data = []
-    with open(csv_file, "r") as f:
+    with gzip.open(gzipped_csv_file, mode="rt") as f:
         reader = csv.reader(f, delimiter=",")
 
         for i, row in enumerate(reader):
@@ -416,7 +417,7 @@ def dissolve_project_data(project_data):
     return dissolved_geometry
 
 
-def generate_tasking_manager_geometries(project_id: str):
+def generate_tasking_manager_geometries(project_id: str, agg_results_filename):
     """
     This functions runs the workflow to create a GeoJSON file ready to be used in the
     HOT Tasking Manager.
@@ -428,14 +429,13 @@ def generate_tasking_manager_geometries(project_id: str):
     Finally, both data sets are saved into GeoJSON files.
     """
 
-    raw_data_filename = f"{DATA_PATH}/api/agg_results/agg_results_{project_id}.csv"
     filtered_data_filename = f"{DATA_PATH}/api/yes_maybe/yes_maybe_{project_id}.geojson"
     tasking_manager_data_filename = (
         f"{DATA_PATH}/api/hot_tm/hot_tm_{project_id}.geojson"
     )
 
     # load project data from existing files
-    results = load_data(project_id, raw_data_filename)
+    results = load_data(project_id, agg_results_filename)
 
     # filter yes and maybe results
     filtered_results = filter_data(results)

--- a/mapswipe_workers/mapswipe_workers/utils/geojson_functions.py
+++ b/mapswipe_workers/mapswipe_workers/utils/geojson_functions.py
@@ -4,7 +4,6 @@ import gzip
 import shutil
 import subprocess
 import tempfile
-from pathlib import Path
 
 from osgeo import ogr, osr
 
@@ -22,7 +21,7 @@ def gzipped_csv_to_gzipped_geojson(
     Then the unzipped csv file is converted into a geojson file with ogr2ogr.
     Last, the generated geojson file is again compressed using gzip.
     """
-    # generate tempory files which will be automatically deleted at the end
+    # generate temporary files which will be automatically deleted at the end
     tmp_csv_file = os.path.join(tempfile._get_default_tempdir(), 'tmp.csv')
     tmp_geojson_file = os.path.join(tempfile._get_default_tempdir(), 'tmp.geojson')
 


### PR DESCRIPTION
This PR uses compression for the files that are exported.

Not all files are compressed, but only these that are relatively big and not used much. In particular we do not compress the tasking manager geometries files that are used by project manager most frequently.

However, the biggest files are `results`, `tasks` and `agg_results` and these (and `groups` and `users`) will be compressed from now on.

Once this PR is merged we need to run the `generate-stats` command for all projects. Then we should remove all "old" files that didn't use compression.

```
docker-compose run -d mapswipe_workers mapswipe_workers --verbose generate-stats-all-projects
```

```
rm -rf mapswipe-data/api/agg_results/*.csv
rm -rf mapswipe-data/api/agg_results/*.geojson
rm -rf mapswipe-data/api/tasks/*.csv
rm -rf mapswipe-data/api/results/*.csv
rm -rf mapswipe-data/api/groups/*.csv
rm -rf mapswipe-data/api/users/*.csv
```