### PR TITLE
do not upload tasks for projects of type build_area

### DIFF
--- a/mapswipe_workers/mapswipe_workers/project_types/base/project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/base/project.py
@@ -213,14 +213,14 @@ class BaseProject(metaclass=ABCMeta):
         task_upload_dict = {}
 
         logger.info(f"there are {len(groupsOfTasks)} groups for this project")
-        c = 0
+        group_counter = 0
 
         if self.projectType in [ProjectType.FOOTPRINT.value]:
             # The building footprint project type is the only one
             # that uses tasks in Firebase.
             for group_id in groupsOfTasks.keys():
                 tasks_list = groupsOfTasks[group_id]
-                c += 1
+                group_counter += 1
                 # for tasks of a building footprint project
                 # we use compression to reduce storage size in firebase
                 # since the tasks hold geometries their storage size
@@ -232,7 +232,9 @@ class BaseProject(metaclass=ABCMeta):
 
                 # we upload tasks in batches of maximum 150 groups
                 # this is to avoid the maximum write size limit in firebase
-                if len(task_upload_dict) % 150 == 0 or c == len(groupsOfTasks):
+                if len(task_upload_dict) % 150 == 0 or group_counter == len(
+                    groupsOfTasks
+                ):
                     ref.update(task_upload_dict)
                     logger.info(
                         f"{self.projectId} -"

--- a/mapswipe_workers/mapswipe_workers/project_types/base/project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/base/project.py
@@ -214,10 +214,13 @@ class BaseProject(metaclass=ABCMeta):
 
         logger.info(f"there are {len(groupsOfTasks)} groups for this project")
         c = 0
-        for group_id in groupsOfTasks.keys():
-            tasks_list = groupsOfTasks[group_id]
-            c += 1
-            if self.projectType in [ProjectType.FOOTPRINT.value]:
+
+        if self.projectType in [ProjectType.FOOTPRINT.value]:
+            # The building footprint project type is the only one
+            # that uses tasks in Firebase.
+            for group_id in groupsOfTasks.keys():
+                tasks_list = groupsOfTasks[group_id]
+                c += 1
                 # for tasks of a building footprint project
                 # we use compression to reduce storage size in firebase
                 # since the tasks hold geometries their storage size
@@ -226,21 +229,24 @@ class BaseProject(metaclass=ABCMeta):
                 task_upload_dict[
                     f"v2/tasks/{self.projectId}/{group_id}"
                 ] = compressed_tasks
-            else:
-                # for all other projects (build_area, completenesss, change detection)
-                # we just upload the tasks without compression
-                task_upload_dict[f"v2/tasks/{self.projectId}/{group_id}"] = tasks_list
 
-            # we upload tasks in batches of maximum 150 groups
-            # this is to avoid the maximum write size limit in firebase
-            if len(task_upload_dict) % 150 == 0 or c == len(groupsOfTasks):
-                ref.update(task_upload_dict)
-                logger.info(
-                    f"{self.projectId} -"
-                    f" uploaded 150 groups with tasks to firebase realtime database"
-                )
-                task_upload_dict = {}
+                # we upload tasks in batches of maximum 150 groups
+                # this is to avoid the maximum write size limit in firebase
+                if len(task_upload_dict) % 150 == 0 or c == len(groupsOfTasks):
+                    ref.update(task_upload_dict)
+                    logger.info(
+                        f"{self.projectId} -"
+                        f" uploaded 150 groups with tasks to firebase realtime database"
+                    )
+                    task_upload_dict = {}
+        else:
+            # For all other projects (build_area, completeness, change detection)
+            # tasks are not needed in Firebase.
+            # The task urls are generated in the app based on the tile server
+            # information which is set in the project attributes in Firebase
+            pass
 
+        # delete project draft in Firebase once all things are in Firebase
         ref = fb_db.reference(f"v2/projectDrafts/{self.projectId}")
         ref.set({})
 

--- a/mapswipe_workers/tests/integration/fixtures/footprint/projectDrafts/footprint.json
+++ b/mapswipe_workers/tests/integration/fixtures/footprint/projectDrafts/footprint.json
@@ -1,0 +1,17 @@
+{
+  "createdBy": "Sample Admin",
+  "inputGeometries": "https://firebasestorage.googleapis.com/v0/b/dev-mapswipe.appspot.com/o/buildings_heidelberg.geojson?alt=media&token=1631f7d4-5fb2-4e1b-a133-2e14582d116c",
+  "image": "http://www.fragosus.com/test/Javita.jpg",
+  "lookFor": "Buildings",
+  "name": "Footprint Sample Project",
+  "projectDetails": "This is a template for a building by building project. We use Bing as the tile server.",
+  "verificationNumber": 3,
+  "groupSize": 35,
+  "projectType": 2,
+  "tileServer": {
+        "name": "bing",
+        "url": "",
+        "apiKey": "",
+        "credits": "© 2019 Microsoft Corporation, Earthstar Geographics SIO"
+      }
+}

--- a/mapswipe_workers/tests/integration/test_create_build_area_project.py
+++ b/mapswipe_workers/tests/integration/test_create_build_area_project.py
@@ -1,0 +1,46 @@
+import unittest
+
+import set_up
+import tear_down
+from click.testing import CliRunner
+
+from mapswipe_workers import auth, mapswipe_workers
+from mapswipe_workers.utils.create_directories import create_directories
+
+
+class TestCreateProject(unittest.TestCase):
+    def setUp(self):
+        self.project_id = set_up.create_test_project_draft(
+            "tile_map_service_grid", "build_area"
+        )
+        create_directories()
+
+    def tearDown(self):
+        tear_down.delete_test_data(self.project_id)
+
+    def test_create_build_area_project(self):
+        runner = CliRunner()
+        runner.invoke(mapswipe_workers.run_create_projects)
+
+        pg_db = auth.postgresDB()
+        query = "SELECT project_id FROM projects WHERE project_id = %s"
+        result = pg_db.retr_query(query, [self.project_id])[0][0]
+        self.assertEqual(result, self.project_id)
+
+        fb_db = auth.firebaseDB()
+        ref = fb_db.reference(f"/v2/projects/{self.project_id}")
+        result = ref.get(shallow=True)
+        self.assertIsNotNone(result)
+
+        ref = fb_db.reference(f"/v2/groups/{self.project_id}")
+        result = ref.get(shallow=True)
+        self.assertIsNotNone(result)
+
+        # Build area project do not have tasks in Firebase
+        ref = fb_db.reference(f"/v2/tasks/{self.project_id}")
+        result = ref.get(shallow=True)
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mapswipe_workers/tests/integration/test_create_footprint_project.py
+++ b/mapswipe_workers/tests/integration/test_create_footprint_project.py
@@ -11,27 +11,34 @@ from mapswipe_workers.utils.create_directories import create_directories
 class TestCreateProject(unittest.TestCase):
     def setUp(self):
         self.project_id = set_up.create_test_project_draft(
-            "tile_map_service_grid", "build_area"
+            "footprint", "footprint"
         )
         create_directories()
 
     def tearDown(self):
         tear_down.delete_test_data(self.project_id)
 
-    def test_create_project(self):
+    def test_create_footprint_project(self):
         runner = CliRunner()
         runner.invoke(mapswipe_workers.run_create_projects)
 
         pg_db = auth.postgresDB()
-        query = "SELECT project_id FROM projects WHERE project_id = '{0}'".format(
-            self.project_id
-        )
-        result = pg_db.retr_query(query)[0][0]
+        query = "SELECT project_id FROM projects WHERE project_id = %s"
+        result = pg_db.retr_query(query, [self.project_id])[0][0]
         self.assertEqual(result, self.project_id)
 
         fb_db = auth.firebaseDB()
-        ref = fb_db.reference("/v2/projects/{0}".format(self.project_id))
-        result = ref.get()
+        ref = fb_db.reference(f"/v2/projects/{self.project_id}")
+        result = ref.get(shallow=True)
+        self.assertIsNotNone(result)
+
+        ref = fb_db.reference(f"/v2/groups/{self.project_id}")
+        result = ref.get(shallow=True)
+        self.assertIsNotNone(result)
+
+        # Footprint projects have tasks in Firebase
+        ref = fb_db.reference(f"/v2/tasks/{self.project_id}")
+        result = ref.get(shallow=True)
         self.assertIsNotNone(result)
 
 


### PR DESCRIPTION
this refers to #344 

Basically, we do not need to upload tasks to Firebase for build area projects, since this is not used by the current version of the app anymore.