### PR TITLE
WIP: Load testing with locust

### DIFF
--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -65,12 +65,12 @@
             ||
             (root.child('/v2/projects/'+$project_id+'/teamId').val() ==
              root.child('/v2/users/'+auth.uid+'/teamId').val())
-          "
-        },
-        ".indexOn": [
-          "finishedCount",
-          "requiredCount"
-        ]
+          ",
+          ".indexOn": [
+            "finishedCount",
+            "requiredCount"
+          ]
+        }
       },
       "tasks": {
         ".write": false,

--- a/mapswipe_workers/locust_files/load_testing.py
+++ b/mapswipe_workers/locust_files/load_testing.py
@@ -1,0 +1,115 @@
+import datetime
+import random
+from uuid import uuid4
+
+from locust import User, between
+
+from mapswipe_workers.utils import user_management
+
+
+class MapSwipeUser(User):
+    wait_time = between(0.5, 10)
+
+    def __init__(self):
+        self.project_id = "-MYg8CEf2k1-RitN62X0"
+        random_string = uuid4()
+        self.email = f"test_{random_string}@mapswipe.org"
+        self.username = f"test_{random_string}"
+        self.password = "mapswipe"
+        self.user_id = None
+        self.signed_in_user = None
+
+    def set_up_user(self):
+        # check if is already signed in
+        if self.signed_in_user is None:
+            print("user is not signed in. Will create a new user.")
+            # create user if not exists
+            user = user_management.create_user(self.email, self.username, self.password)
+            self.user_id = user.uid
+
+            # sign in user
+            self.signed_in_user = user_management.sign_in_with_email_and_password(
+                self.email, self.password
+            )
+            print("Created a new user.")
+        else:
+            print("user is already signed in.")
+            pass
+
+    def create_mock_result(self, group):
+        start_time = datetime.datetime.utcnow().isoformat()[0:-3] + "Z"
+        end_time = datetime.datetime.utcnow().isoformat()[0:-3] + "Z"
+
+        x_min = int(group["xMin"])
+        x_max = int(group["xMax"])
+        y_min = int(group["yMin"])
+        y_max = int(group["yMax"])
+
+        results = {}
+        for x in range(x_min, x_max):
+            for y in range(y_min, y_max):
+                task_id = f"18-{x}-{y}"
+                result = random.choices([0, 1, 2, 3])[0]  # no, yes, maybe, bad_imagery
+                results[task_id] = result
+
+        data = {
+            "results": results,
+            "timestamp": end_time,
+            "startTime": start_time,
+            "endTime": end_time,
+        }
+        return data
+
+    def map_a_group(self):
+        """Get a group from Firebase for this user.
+
+        Make sure that this user has not worked on this group before.
+        """
+
+        # get the groups that need to be mapped
+        path = f"/v2/groups/{self.project_id}"
+        # make sure to set '&' at the end of the string
+        custom_arguments = 'orderBy="requiredCount"&limitToLast=15&'
+        new_groups = user_management.get_firebase_db(
+            path, custom_arguments, self.signed_in_user["idToken"]
+        )
+
+        # get the groups the user has worked on already
+        path = f"/v2/users/{self.user_id}/contributions/{self.project_id}"
+        # make sure to set & at the end of the string
+        custom_arguments = "shallow=True&"
+        existing_groups = user_management.get_firebase_db(
+            path, custom_arguments, self.signed_in_user["idToken"]
+        )
+
+        # pick group for mapping
+        # Get difference between new_groups and existing groups.
+        # We should get the groups the user has not yet worked on.
+        if existing_groups is None:
+            next_group_id = random.choice(list(new_groups.keys()))
+        else:
+            existing_groups.pop(
+                "taskContributionCount", None
+            )  # need to remove this since it is no groupId
+            remaining_group_ids = list(
+                set(new_groups.keys()) - set(existing_groups.keys())
+            )
+            next_group_id = random.choice(remaining_group_ids)
+
+        # get group object
+        next_group = new_groups[next_group_id]
+
+        # create mock result for this group
+        result = self.create_mock_result(next_group)
+
+        # upload results in firebase
+        path = f"/v2/results/{self.project_id}/{next_group_id}/{self.user_id}"
+        user_management.set_firebase_db(path, result, self.signed_in_user["idToken"])
+
+
+if __name__ == "__main__":
+    mapswipe_user = MapSwipeUser()
+    mapswipe_user.set_up_user()
+    mapswipe_user.map_a_group()
+    mapswipe_user.map_a_group()
+    mapswipe_user.map_a_group()

--- a/mapswipe_workers/locust_files/load_testing.py
+++ b/mapswipe_workers/locust_files/load_testing.py
@@ -1,4 +1,4 @@
-# run with locust -f locust_files/load_testing.py
+# run with "locust -f locust_files/load_testing.py"
 # then set number of users and spawn rate in web interface
 # e.g. test with 100 users, and 15 users/sec
 # web interface: http://0.0.0.0:8089/
@@ -36,6 +36,10 @@ class MapSwipeUser(HttpUser):
             pass
 
     def create_mock_result(self, group):
+        """Create a result object for a build area project.
+
+        The result values are generated randomly.
+        """
         start_time = datetime.datetime.utcnow().isoformat()[0:-3] + "Z"
         end_time = datetime.datetime.utcnow().isoformat()[0:-3] + "Z"
 
@@ -59,6 +63,7 @@ class MapSwipeUser(HttpUser):
         return data
 
     def set_firebase_db(self, path, data, token=None):
+        """Upload results to Firebase using REST api."""
         request_ref = f"{path}.json?auth={token}"
         headers = {"content-type": "application/json; charset=UTF-8"}
         self.client.patch(
@@ -68,9 +73,11 @@ class MapSwipeUser(HttpUser):
 
     @task
     def map_a_group(self):
-        """Get a group from Firebase for this user.
+        """Get a group from Firebase for this user and "map" it.
 
         Make sure that this user has not worked on this group before.
+        Get the group and create mock results.
+        Upload results to Firebse.
         """
 
         # get the groups that need to be mapped
@@ -114,6 +121,7 @@ class MapSwipeUser(HttpUser):
         self.set_firebase_db(path, result, self.signed_in_user["idToken"])
 
     def on_start(self):
+        """Set up user and define project when user starts running."""
         self.project_id = "-MYg8CEf2k1-RitN62X0"
         random_string = uuid4()
         self.email = f"test_{random_string}@mapswipe.org"

--- a/mapswipe_workers/locust_files/load_testing.py
+++ b/mapswipe_workers/locust_files/load_testing.py
@@ -66,7 +66,7 @@ class MapSwipeUser(HttpUser):
         """Upload results to Firebase using REST api."""
         request_ref = f"{path}.json?auth={token}"
         headers = {"content-type": "application/json; charset=UTF-8"}
-        self.client.patch(
+        self.client.put(
             request_ref, headers=headers, data=json.dumps(data).encode("utf-8")
         )
         logger.info(f"set data in firebase for {path}.json")

--- a/mapswipe_workers/mapswipe_workers/firebase_to_postgres/transfer_results.py
+++ b/mapswipe_workers/mapswipe_workers/firebase_to_postgres/transfer_results.py
@@ -11,7 +11,6 @@ from mapswipe_workers.firebase_to_postgres import update_data
 
 def transfer_results(project_id_list=None):
     """Transfer results for one project after the other.
-
     Will only trigger the transfer of results for projects
     that are defined in the postgres database.
     Will not transfer results for tutorials and
@@ -57,28 +56,22 @@ def transfer_results(project_id_list=None):
 
 def transfer_results_for_project(project_id, results):
     """Transfer the results for a specific project.
-
     Save results into an in-memory file.
     Copy the results to postgres.
     Delete results in firebase.
-
     We are NOT using a Firebase transaction functions here anymore.
     This has caused problems, in situations where a lot of mappers are
     uploading results to Firebase at the same time. Basically, this is
     due to the behaviour of Firebase Transaction function:
-
         "If another client writes to this location
         before the new value is successfully saved,
         the update function is called again with the new current value,
         and the write will be retried."
-
     (source: https://firebase.google.com/docs/reference/admin/python/firebase_admin.db#firebase_admin.db.Reference.transaction)  # noqa
-
     Using Firebase transaction on the group level
     has turned out to be too slow when using "normal" queries,
     e.g. without using threading. Threading should be avoided here
     as well to not run into unforeseen errors.
-
     For more details see issue #478.
     """
 
@@ -125,7 +118,6 @@ def transfer_results_for_project(project_id, results):
 
 def delete_results_from_firebase(project_id, results):
     """Delete results from Firebase using update function.
-
     We use the update method of firebase instead of delete.
     Update allows to delete items at multiple locations at the same time
     and is much faster.

--- a/mapswipe_workers/mapswipe_workers/firebase_to_postgres/transfer_results.py
+++ b/mapswipe_workers/mapswipe_workers/firebase_to_postgres/transfer_results.py
@@ -291,6 +291,7 @@ def save_results_to_postgres(results_file):
     """
     p_con.query(query_insert_results)
     del p_con
+    logger.info("copied results into postgres.")
 
 
 def truncate_temp_results():


### PR DESCRIPTION
this refers to #482 

[Locust](https://locust.io/) is used to test how many results the `transfer_results` function can handle.

For testing we set up new users in Firebase, that do some mapping in a real project. I tested the "old" version of the transfer results function which used a transaction function and the new version, where we just delete the transfered groups within an update function.

Note: Firebase DB rules needed to be changed to account for an missing index on the `requiredCount` of a group. It's a bit weird, why this has worked before. Is the app not using the requiredCount?

### old version of the backend
#### 25 users
* 25 users, spawn rate: 1user/sec
* each user's wait time between 30 sec and 120 sec
* ~0.3 requests (groups results uploaded) per second
* backend needs 3 attempts to transfer results within one transaction, but can handle

#### 50 users
* 50 users, spawn rate: 1user/sec
* each user's wait time between 30 sec and 120 sec
* ~0.7 requests (groups results uploaded) per second
* backend needs 3-5 attempts to transfer results within one transaction, but can still handle

#### 100 users
* 100 users, spawn rate: 1user/sec
* each user's wait time between 30 sec and 120 sec
* ~1.5 requests (groups results uploaded) per second
* backend needs >25 attempts to transfer results within one transaction
* raises TransactionAborted error
* backend can't handle it anymore

### new version of transfer_results

#### 100 users
* 100 users, spawn rate: 1user/sec
* each user's wait time between 30 sec and 120 sec
* ~1.5 requests (groups results uploaded) per second
* workers running every 2 minutes
* backend needs ~7 sec to transfer all results for a project

#### 250 users
* 250 users, spawn rate: 10 users/sec
* each user's wait time between 30 sec and 120 sec
* ~1.5 requests per second --> 4 x 60 x 2 = 480 groups in 2 minutes
* workers running every 2 minutes
* backend needs ~15 sec to transfer all results for a project

#### 1000 users
* 1000 users, spawn rate: 10 users/sec
* each user's wait time between 30 sec and 120 sec
* ~15 requests per second
* workers running every 2 minutes
* backend needs ~70 sec to transfer all results for a project