### PR TITLE
Fix wrong area threshold

### DIFF
--- a/manager_dashboard/manager_dashboard/js/forms.js
+++ b/manager_dashboard/manager_dashboard/js/forms.js
@@ -233,7 +233,10 @@ function openFile(event) {
 
               // check project size, based on zoom level
               var zoomLevel = parseInt(document.getElementById('zoomLevel').value);
-              maxArea = (23 - zoomLevel) * (23 - zoomLevel) * 200
+              // 20,480 sqkm for zoom 17
+              //  5,120 sqkm for zooom 18
+              //  1,280 sqkm for zoom 19
+              maxArea = 5 * (4 ** (23 - zoomLevel))
               console.log('project size: ' + sumArea + ' sqkm')
 
               if (sumArea > maxArea) {

--- a/mapswipe_workers/mapswipe_workers/project_types/tile_map_service_grid/project.py
+++ b/mapswipe_workers/mapswipe_workers/project_types/tile_map_service_grid/project.py
@@ -154,10 +154,9 @@ class Project(BaseProject):
         # We calculate the max area based on zoom level.
         # This is an approximation to restrict the project size
         # in respect to the number of tasks.
-        # At zoom level 22 the max area is set to 200 square kilometers.
-        # For zoom level 18 this will result in an max area of 5000 square kilometers.
-        # (23-18) * (23-18) * 200 = 5000
-        max_area = (23 - int(self.zoomLevel)) * (23 - int(self.zoomLevel)) * 200
+        # At zoom level 22 the max area is set to 20 square kilometers.
+        # For zoom level 18 this will result in an max area of 5,120 square kilometers.
+        max_area = 5 * 4 ** (23 - self.zoomLevel)
 
         if project_area > max_area:
             logger.warning(


### PR DESCRIPTION
We used a wrong threshold for the max area per project.

for zoom 18 we want to have a max size around 5,000 sqkm.
For zoom 17 it can be 4 times that --> 20,000 since this will refer to the same number of tasks.