### PR TITLE
adjust sql query to make sure to select all invalid results to delete

### DIFF
--- a/mapswipe_workers/mapswipe_workers/firebase_to_postgres/transfer_results.py
+++ b/mapswipe_workers/mapswipe_workers/firebase_to_postgres/transfer_results.py
@@ -305,6 +305,10 @@ def save_results_to_postgres(results_file, project_id, filter_mode: bool):
                 from tasks
                 where project_id = %(project_id)s
             ),
+            -- Results for which we can't join a task from the tasks table
+            -- are invalid. For these invalid results the group_id set by the app
+            -- is not correct. Hence, we delete these results from the
+            -- results_temp table.
             results_to_delete as (
                 select
                     r.task_id


### PR DESCRIPTION
the previous solution didn't remove all invalid tasks. There could have been a situation where the task_id was twice listed in the results. E.g. one time for a valid result and another time for an invalid result. In such a situation the invalid result would not have been removed. 

This triggered many error messages in Sentry because the transfer of results from firebase to postgres is performed every 2 minutes (and failed every two minutes for the project)