### PR TITLE
Add skeleton Makefile for common commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ workers_status:
 
 danger_restart_project_creation_worker:
         docker compose up -d mapswipe_workers_creation
+
+make_project_manager:
+        @echo "run with email=thing@domain.com to give PM rights"; docker compose run mapswipe_workers_creation mapswipe_workers -v user-management --action=add-manager-rights --email=$(email)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# This Makefile aims to make daily mapswipe admin tasks a bit easier by collecting
+# all common commands here, with a simple built-in help system.
+# On the command line, just type "make<space><tab>"
+#
+# prefix all risky commands with "danger_" :)
+
+workers_status:
+        docker ps -a
+
+danger_restart_project_creation_worker:
+        docker compose up -d mapswipe_workers_creation

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,27 @@
-# This Makefile aims to make daily mapswipe admin tasks a bit easier by collecting
+# This Makefile aims to make daily admin tasks a bit easier by collecting
 # all common commands here, with a simple built-in help system.
 # On the command line, just type "make<space><tab>"
-#
-# prefix all risky commands with "danger_" :)
 
 workers_status:
         docker ps -a
 
-danger_restart_project_creation_worker:
+restart_project_creation_worker:
         docker compose up -d mapswipe_workers_creation
 
+start_all_workers:
+        docker compose up -d postgres manager_dashboard nginx api mapswipe_workers_creation mapswipe_workers_stats mapswipe_workers_firebase_to_postgres
+
+stop_all_workers:
+        docker compose stop
+
 make_project_manager:
-        @echo "run with email=thing@domain.com to give PM rights"; docker compose run mapswipe_workers_creation mapswipe_workers -v user-management --action=add-manager-rights --email=$(email)
+        @echo "run with email=thing@domain.com to give PM rights"; docker compose run --rm mapswipe_workers_creation mapswipe_workers -v user-management --action=add-manager-rights --email=$(email)
+
+remove_project_manager:
+        @echo "run with email=thing@domain.com to remove PM rights"; docker compose run --rm mapswipe_workers_creation mapswipe_workers -v user-management --action=remove-manager-right --email=$(email)
+
+update_firebase_functions_and_db_rules:
+        docker compose run --rm firebase_deploy
+
+deploy_latest_workers_version:
+        git pull; docker compose build postgres manager_dashboard nginx api mapswipe_workers_creation mapswipe_workers_stats mapswipe_workers_firebase_to_postgres firebase_deploy; docker compose up -d postgres manager_dashboard nginx api mapswipe_workers_creation mapswipe_workers_stats mapswipe_workers_firebase_to_postgres firebase_deploy


### PR DESCRIPTION
This PR is to track the creation of a `Makefile` which will contain important commands that we use regularly to manage mapswipe backend servers.

The goal is not to be exhaustive, merely to provide a simple list of daily actions that could be managed by more than 1-2 people, and therefore reduce bottlenecks.

Feel free to suggest additions in the PR, even if you don't know how to implement.