### PR TITLE
Skip footprint mission area swiped.

### DIFF
--- a/mapswipe_workers/mapswipe_workers/firebase_to_postgres/transfer_results.py
+++ b/mapswipe_workers/mapswipe_workers/firebase_to_postgres/transfer_results.py
@@ -88,8 +88,8 @@ def transfer_results_for_project(project_id, results, filter_mode: bool = False)
                 [
                     user_group_id
                     for _, users in results.items()
-                    for _, results in users.items()
-                    for user_group_id, is_selected in results.get(
+                    for _, _results in users.items()
+                    for user_group_id, is_selected in _results.get(
                         "userGroups", {}
                     ).items()
                     if is_selected

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -51,6 +51,7 @@ server {
 
     location / {
         proxy_pass http://django:80/;
+        proxy_cache_valid 502 503 0;  # Don't cache this error code.
         proxy_set_header Connection "upgrade";
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Address
- https://github.com/mapswipe/mapswipe-meta/issues/93
    > confirm that "Total area swiped" does not include stats from the footprint validation type missions. that is, it should only be 'build area missions sq km' + 'change detection missions sq km' + 'completeness missions sq km'.
 - Nginx skip caching 502 and 503.

NOTE:
To clear out pre-calculate aggregated data.
- Users Stats
```sql
UPDATE
  aggregated_aggregateduserstatdata
SET area_swiped = 0
WHERE project_id in (
  SELECT project_id FROM projects where project_type = 2
)
```

- UserGroups Stats
```sql
UPDATE
  aggregated_aggregatedusergroupstatdata
SET area_swiped = 0
WHERE project_id in (
  SELECT project_id FROM projects where project_type = 2
)
```