### PR TITLE
Configure project types available in manager dashboard

### DIFF
--- a/manager-dashboard/app/Base/configs/projectTypes.ts
+++ b/manager-dashboard/app/Base/configs/projectTypes.ts
@@ -1,0 +1,33 @@
+import {
+    ProjectType,
+    PROJECT_TYPE_BUILD_AREA,
+    PROJECT_TYPE_FOOTPRINT,
+    PROJECT_TYPE_CHANGE_DETECTION,
+    PROJECT_TYPE_COMPLETENESS,
+} from '#utils/common';
+
+const PROJECT_CONFIG_NAME = process.env.REACT_APP_PROJECT_CONFIG_NAME as string;
+
+const defaultProjectTypeOptions: {
+    value: ProjectType;
+    label: string;
+}[] = [
+    { value: PROJECT_TYPE_BUILD_AREA, label: 'Build Area' },
+    { value: PROJECT_TYPE_FOOTPRINT, label: 'Footprint' },
+    { value: PROJECT_TYPE_CHANGE_DETECTION, label: 'Change Detection' },
+    { value: PROJECT_TYPE_COMPLETENESS, label: 'Completeness' },
+];
+
+const developmentProjectTypeOptions: {
+    value: ProjectType;
+    label: string;
+}[] = [
+    { value: PROJECT_TYPE_BUILD_AREA, label: 'Build Area' },
+    { value: PROJECT_TYPE_FOOTPRINT, label: 'Footprint' },
+    { value: PROJECT_TYPE_CHANGE_DETECTION, label: 'Change Detection' },
+    // { value: PROJECT_TYPE_COMPLETENESS, label: 'Completeness' },
+];
+
+const projectTypeOptions = PROJECT_CONFIG_NAME === 'development' ? developmentProjectTypeOptions : defaultProjectTypeOptions;
+
+export default projectTypeOptions;

--- a/manager-dashboard/app/Base/configs/projectTypes.ts
+++ b/manager-dashboard/app/Base/configs/projectTypes.ts
@@ -25,7 +25,7 @@ const developmentProjectTypeOptions: {
     { value: PROJECT_TYPE_BUILD_AREA, label: 'Build Area' },
     { value: PROJECT_TYPE_FOOTPRINT, label: 'Footprint' },
     { value: PROJECT_TYPE_CHANGE_DETECTION, label: 'Change Detection' },
-    // { value: PROJECT_TYPE_COMPLETENESS, label: 'Completeness' },
+    { value: PROJECT_TYPE_COMPLETENESS, label: 'Completeness' },
 ];
 
 const projectTypeOptions = PROJECT_CONFIG_NAME === 'development' ? developmentProjectTypeOptions : defaultProjectTypeOptions;

--- a/manager-dashboard/app/Base/configs/projectTypes.ts
+++ b/manager-dashboard/app/Base/configs/projectTypes.ts
@@ -8,7 +8,7 @@ import {
 
 const PROJECT_CONFIG_NAME = process.env.REACT_APP_PROJECT_CONFIG_NAME as string;
 
-const defaultProjectTypeOptions: {
+const mapswipeProjectTypeOptions: {
     value: ProjectType;
     label: string;
 }[] = [
@@ -18,16 +18,14 @@ const defaultProjectTypeOptions: {
     { value: PROJECT_TYPE_COMPLETENESS, label: 'Completeness' },
 ];
 
-const developmentProjectTypeOptions: {
+const crowdmapProjectTypeOptions: {
     value: ProjectType;
     label: string;
 }[] = [
     { value: PROJECT_TYPE_BUILD_AREA, label: 'Build Area' },
-    { value: PROJECT_TYPE_FOOTPRINT, label: 'Footprint' },
-    { value: PROJECT_TYPE_CHANGE_DETECTION, label: 'Change Detection' },
     { value: PROJECT_TYPE_COMPLETENESS, label: 'Completeness' },
 ];
 
-const projectTypeOptions = PROJECT_CONFIG_NAME === 'development' ? developmentProjectTypeOptions : defaultProjectTypeOptions;
+const projectTypeOptions = PROJECT_CONFIG_NAME === 'crowdmap' ? crowdmapProjectTypeOptions : mapswipeProjectTypeOptions;
 
 export default projectTypeOptions;

--- a/manager-dashboard/app/views/NewProject/index.tsx
+++ b/manager-dashboard/app/views/NewProject/index.tsx
@@ -62,7 +62,6 @@ import {
     projectFormSchema,
     ProjectFormType,
     PartialProjectFormType,
-    projectTypeOptions,
     projectInputTypeOptions,
     filterOptions,
     PROJECT_INPUT_TYPE_UPLOAD,
@@ -77,6 +76,8 @@ import {
 } from './utils';
 import useProjectOptions from './useProjectOptions';
 import styles from './styles.css';
+
+import projectTypeOptions from '#base/configs/projectTypes';
 
 const defaultProjectFormValue: PartialProjectFormType = {
     projectType: PROJECT_TYPE_BUILD_AREA,

--- a/manager-dashboard/app/views/NewProject/utils.ts
+++ b/manager-dashboard/app/views/NewProject/utils.ts
@@ -58,16 +58,6 @@ export interface ProjectFormType {
     tileServerB?: TileServer;
 }
 
-export const projectTypeOptions: {
-    value: ProjectType;
-    label: string;
-}[] = [
-    { value: PROJECT_TYPE_BUILD_AREA, label: 'Build Area' },
-    { value: PROJECT_TYPE_FOOTPRINT, label: 'Footprint' },
-    { value: PROJECT_TYPE_CHANGE_DETECTION, label: 'Change Detection' },
-    { value: PROJECT_TYPE_COMPLETENESS, label: 'Completeness' },
-];
-
 export const PROJECT_INPUT_TYPE_UPLOAD = 'aoi_file';
 export const PROJECT_INPUT_TYPE_LINK = 'link';
 export const PROJECT_INPUT_TYPE_TASKING_MANAGER_ID = 'TMId';

--- a/manager-dashboard/app/views/NewTutorial/index.tsx
+++ b/manager-dashboard/app/views/NewTutorial/index.tsx
@@ -55,9 +55,10 @@ import {
     tutorialFormSchema,
     TutorialFormType,
     PartialTutorialFormType,
-    projectTypeOptions,
 } from './utils';
 import styles from './styles.css';
+
+import projectTypeOptions from '#base/configs/projectTypes';
 
 const defaultTutorialFormValue: PartialTutorialFormType = {
     projectType: PROJECT_TYPE_BUILD_AREA,

--- a/manager-dashboard/app/views/NewTutorial/utils.ts
+++ b/manager-dashboard/app/views/NewTutorial/utils.ts
@@ -17,20 +17,9 @@ import {
     getNoMoreThanNCharacterCondition,
     ProjectType,
     PROJECT_TYPE_BUILD_AREA,
-    PROJECT_TYPE_FOOTPRINT,
     PROJECT_TYPE_CHANGE_DETECTION,
     PROJECT_TYPE_COMPLETENESS,
 } from '#utils/common';
-
-export const projectTypeOptions: {
-    value: ProjectType;
-    label: string;
-}[] = [
-    { value: PROJECT_TYPE_BUILD_AREA, label: 'Build Area' },
-    { value: PROJECT_TYPE_FOOTPRINT, label: 'Footprint' },
-    { value: PROJECT_TYPE_CHANGE_DETECTION, label: 'Change Detection' },
-    { value: PROJECT_TYPE_COMPLETENESS, label: 'Completeness' },
-];
 
 // FIXME: include here
 export interface TutorialFormType {


### PR DESCRIPTION
With these changes you can specifiy which projects types are supported in the manager dashboard. There is the `default` mapswipe configuration which supports the know 4 project types (build_area, footprint, change_detection, completeness).

This change will allow us to add more project types in the future step by step, but gives the option to not directly deploy them to the manager dashboard or make them publicly available.