### PR TITLE
Add threshold for time-spent calculation

### DIFF
--- a/django/apps/aggregated/management/commands/update_aggregated_data.py
+++ b/django/apps/aggregated/management/commands/update_aggregated_data.py
@@ -6,10 +6,42 @@ from apps.aggregated.models import (
     AggregatedUserGroupStatData,
     AggregatedUserStatData,
 )
-from apps.existing_database.models import MappingSession
+from apps.existing_database.models import MappingSession, Project
 from django.core.management.base import BaseCommand
 from django.db import connection, models, transaction
 from django.utils import timezone
+
+# Factor calculated by @Hagellach37
+# For defining the threshold for outliers using `95_percent`
+# Used by TASK_GROUP_METADATA_QUERY
+# |project_type|median|95_percent|avg|
+# |------------|------|----------|---|
+# |1|00:00:00.208768|00:00:01.398161|00:00:28.951521|
+# |2|00:00:01.330297|00:00:06.076814|00:00:03.481192|
+# |3|00:00:02.092967|00:00:11.271081|00:00:06.045881|
+TASK_GROUP_METADATA_QUERY = f"""
+          SELECT
+              project_id,
+              group_id,
+              SUM(
+                ST_Area(geom::geography(GEOMETRY,4326)) / 1000000
+              ) as total_task_group_area, -- sqkm
+              (
+                CASE
+                  -- Using 95_percent value of existing data for each project_type
+                  WHEN UG.project_type = {Project.Type.BUILD_AREA.value} THEN 1.4
+                  WHEN UG.project_type = {Project.Type.COMPLETENESS.value} THEN 1.4
+                  WHEN UG.project_type = {Project.Type.CHANGE_DETECTION.value} THEN 11.2
+                  -- FOOTPRINT: Not calculated right now
+                  WHEN UG.project_type = {Project.Type.FOOTPRINT.value} THEN 6.1
+                  ELSE 1
+                END
+              ) * COUNT(*) as time_spent_max_allowed
+          FROM tasks T
+              INNER JOIN used_task_groups UG USING (project_id, group_id)
+          GROUP BY project_id, project_type, group_id
+"""
+
 
 UPDATE_USER_DATA_SQL = f"""
     INSERT INTO "{AggregatedUserStatData._meta.db_table}" (
@@ -26,26 +58,19 @@ UPDATE_USER_DATA_SQL = f"""
         WITH used_task_groups as (
             SELECT
               MS.project_id,
+              P.project_type,
               MS.group_id
             FROM mapping_sessions MS
                 INNER JOIN projects P USING (project_id)
             WHERE
-                MS.start_time >= %(from_date)s and MS.start_time < %(until_date)s
-                AND P.project_type != 2 -- Skip for footprint type missions
-            GROUP BY project_id, group_id -- To get unique
+                -- Skip for footprint type missions
+                P.project_type != {Project.Type.FOOTPRINT.value}
+                AND MS.start_time >= %(from_date)s
+                AND MS.start_time < %(until_date)s
+            GROUP BY project_id, project_type, group_id -- To get unique
         ),
         -- Calculated area by task_groups
-        task_group_area_data as (
-          SELECT
-              project_id,
-              group_id,
-              SUM(
-                ST_Area(geom::geography(GEOMETRY,4326)) / 1000000
-              ) as total_task_group_area -- sqkm
-          FROM tasks T
-              INNER JOIN used_task_groups UG USING (project_id, group_id)
-          GROUP BY project_id, group_id
-        ),
+        task_group_metadata as ({TASK_GROUP_METADATA_QUERY}),
         -- Aggregate data by user
         user_data as (
             SELECT
@@ -53,14 +78,17 @@ UPDATE_USER_DATA_SQL = f"""
               MS.group_id,
               MS.user_id,
               MS.start_time::date as timestamp_date,
-              MS.start_time,
-              MS.end_time,
+              LEAST(
+                  EXTRACT(EPOCH FROM (MS.end_time - MS.start_time)),
+                  TG.time_spent_max_allowed
+              ) as time_spent_sec,
               MS.items_count as task_count,
               Coalesce(TG.total_task_group_area, 0) as area_swiped
             FROM mapping_sessions MS
-                LEFT JOIN task_group_area_data TG USING (project_id, group_id)
+                LEFT JOIN task_group_metadata TG USING (project_id, group_id)
             WHERE
-                MS.start_time >= %(from_date)s and MS.start_time < %(until_date)s
+                MS.start_time >= %(from_date)s
+                AND MS.start_time < %(until_date)s
         ),
         -- Additional aggregate by timestamp_date
         user_agg_data as (
@@ -68,7 +96,7 @@ UPDATE_USER_DATA_SQL = f"""
             project_id,
             user_id,
             timestamp_date,
-            COALESCE(SUM(EXTRACT(EPOCH FROM (end_time - start_time))), 0) as total_time,
+            COALESCE(SUM(time_spent_sec), 0) as total_time,
             COALESCE(SUM(task_count), 0) as task_count,
             COALESCE(SUM(area_swiped), 0) as area_swiped
           FROM user_data
@@ -92,7 +120,6 @@ UPDATE_USER_DATA_SQL = f"""
         swipes = EXCLUDED.swipes;
 """
 
-
 UPDATE_USER_GROUP_SQL = f"""
     INSERT INTO "{AggregatedUserGroupStatData._meta.db_table}" (
         project_id,
@@ -109,27 +136,20 @@ UPDATE_USER_GROUP_SQL = f"""
         WITH used_task_groups as (
             SELECT
               MS.project_id,
+              P.project_type,
               MS.group_id
-            From mapping_sessions_user_groups MSUR
+            FROM mapping_sessions_user_groups MSUR
                 INNER JOIN mapping_sessions MS USING (mapping_session_id)
                 INNER JOIN projects P USING (project_id)
             WHERE
-                MS.start_time >= %(from_date)s and MS.start_time < %(until_date)s
-                AND P.project_type != 2 -- Skip for footprint type missions
-            GROUP BY project_id, group_id -- To get unique
+                -- Skip for footprint type missions
+                P.project_type != {Project.Type.FOOTPRINT.value}
+                AND MS.start_time >= %(from_date)s
+                AND MS.start_time < %(until_date)s
+            GROUP BY project_id, project_type, group_id -- To get unique
         ),
         -- Calculated area by task_groups
-        task_group_area_data as (
-          SELECT
-              project_id,
-              group_id,
-              SUM(
-                ST_Area(geom::geography(GEOMETRY,4326)) / 1000000
-              ) as total_task_group_area -- sqkm
-          FROM tasks T
-              INNER JOIN used_task_groups UG USING (project_id, group_id)
-          GROUP BY project_id, group_id
-        ),
+        task_group_metadata as ({TASK_GROUP_METADATA_QUERY}),
         -- Aggregate data by user-group
         user_group_data as (
             SELECT
@@ -138,15 +158,18 @@ UPDATE_USER_GROUP_SQL = f"""
                 MS.user_id,
                 MSUR.user_group_id,
                 MS.start_time::date as timestamp_date,
-                MS.start_time as start_time,
-                MS.end_time as end_time,
+                LEAST(
+                    EXTRACT(EPOCH FROM (MS.end_time - MS.start_time)),
+                    TG.time_spent_max_allowed
+                ) as time_spent_sec,
                 MS.items_count as task_count,
                 Coalesce(TG.total_task_group_area, 0) as area_swiped
-            From mapping_sessions_user_groups MSUR
+            FROM mapping_sessions_user_groups MSUR
                 INNER JOIN mapping_sessions MS USING (mapping_session_id)
-                LEFT JOIN task_group_area_data TG USING (project_id, group_id)
+                LEFT JOIN task_group_metadata TG USING (project_id, group_id)
             WHERE
-                MS.start_time >= %(from_date)s and MS.start_time < %(until_date)s
+                MS.start_time >= %(from_date)s
+                AND MS.start_time < %(until_date)s
         ),
         -- Additional aggregate by timestamp_date
         user_group_agg_data as (
@@ -155,7 +178,7 @@ UPDATE_USER_GROUP_SQL = f"""
             user_id,
             user_group_id,
             timestamp_date,
-            COALESCE(SUM(EXTRACT(EPOCH FROM (end_time - start_time))), 0) as total_time,
+            COALESCE(SUM(time_spent_sec), 0) as total_time,
             COALESCE(SUM(task_count), 0) as task_count,
             COALESCE(SUM(area_swiped), 0) as area_swiped
           FROM user_group_data


### PR DESCRIPTION
For defining the threshold for outliers using `95_percent`
Used by TASK_GROUP_METADATA_QUERY
|project_type|median|95_percent|avg|
|------------|------|----------|---|
|1|00:00:00.208768|00:00:01.398161|00:00:28.951521|
|2|00:00:01.330297|00:00:06.076814|00:00:03.481192|
|3|00:00:02.092967|00:00:11.271081|00:00:06.045881|


## Post deployment steps
It took around 14 Hours to re-calculate all the stats using a single SQL query.
It might take more by Django as we are calculating in batch.


Steps are as:
- [ ] Stop the django-schedule-task container
- [ ] Remove all data from aggregated tables
  ```sql
  DELETE FROM aggregated_aggregatedtracking;
  DELETE FROM aggregated_aggregatedusergroupstatdata;
  DELETE FROM aggregated_aggregateduserstatdata;
  ```
- [ ] Start the aggregated calculation
  ```bash
  tmux  # It can take some time, so tmux/screen is useful here
  docker-compose exec django ./manage.py update_aggregated_data
  ```
- [ ] Start the django-schedule-task container