### PR TITLE
Add script for backtrack calculation

### DIFF
--- a/postgres/scripts/backtrack_user_group_mapping_sessions.sql
+++ b/postgres/scripts/backtrack_user_group_mapping_sessions.sql
@@ -1,0 +1,64 @@
+-- https://docs.google.com/spreadsheets/d/1g92Rj02LVqvYBFmdnf5CBs8IwuD0GjXP0b1A-H9SvQY/edit#gid=0
+
+WITH
+    -- Collect user_group_id
+    cq_user_group_ids as (
+        SELECT
+            user_groups.user_group_id
+        FROM user_groups
+        WHERE user_groups.name in (
+            'Amazon',
+            'Cisco',
+            'Grainger',
+            'Hewlett Packard Enterprise',
+            'HP Inc.',
+            'Intel',
+            'Lenovo',
+            'Mastercard',
+            'PwC',
+            'Assurant',
+            'Microsoft',
+            'Paramount Global',
+            'Flex',
+            'Rodan + Fields',
+            'Pitney Bowes',
+            'Lockheed Martin Corporation',
+            'Fanatics',
+            'Zurich NA',
+            'Triumph Group',
+            'Leonardo DRS',
+            'McKinsey & Co.',
+            'Pyramid Systems'
+        )
+    ),
+    -- Collect user_group_id+user_id
+    cq_user_group_ids_and_user_ids as (
+        SELECT
+            user_group_id,
+            user_id
+        FROM user_groups_user_memberships
+        WHERE
+            user_group_id in (SELECT * FROM cq_user_group_ids)
+            AND is_active is True
+    )
+-- Insert all user_id mapping session (Year: 2022+) to user_group_id
+INSERT INTO mapping_sessions_user_groups(
+  mapping_session_id,
+  user_group_id
+)
+(
+  SELECT
+    MS.mapping_session_id,
+    CQ_UG_IDS.user_group_id
+  FROM mapping_sessions MS
+      JOIN cq_user_group_ids_and_user_ids CQ_UG_IDS USING (user_id)
+  WHERE MS.end_time >= '2022-01-01'
+) ON CONFLICT (mapping_session_id, user_group_id) DO NOTHING;
+
+-- This table is maintaned using django
+-- type = 1 = USER_GROUP
+-- value = date from when the data is calculated >= 2022-01-01
+-- To update aggregated data: docker-compose exec django ./manage.py update_aggregated_data.py
+UPDATE aggregated_aggregatedtracking
+SET "value" = '2022-01-01'
+WHERE "type" = 1;


### PR DESCRIPTION
Issue:
- https://github.com/mapswipe/mapswipe-meta/issues/13

## NOTE
Before running the SQL script, generate a user-group mapping session table CSV dump (If we need to revert back changes)
```bash
docker-compose exec postgres psql -U mapswipe_workers mapswipe -c '\copy (SELECT * FROM mapping_sessions_user_groups) to STDOUT CSV HEADER;' > /tmp/user-group-session-data-`date +%Y-%m-%d.%H:%M:%S`.csv
```
Running the SQL Script and aggregated data calculation
```bash
docker-compose exec -T postgres bash -c 'psql -U $POSTGRES_USER $POSTGRES_DB' < postgres/scripts/backtrack_user_group_mapping_sessions.sql
docker-compose exec django ./manage.py update_aggregated_data
```