### PR TITLE
Fix footprint time threshold calculation logic

### DIFF
--- a/django/apps/aggregated/management/commands/update_aggregated_data.py
+++ b/django/apps/aggregated/management/commands/update_aggregated_data.py
@@ -75,12 +75,14 @@ UPDATE_PROJECT_GROUP_DATA = f"""
 
 TASK_GROUP_METADATA_QUERY = f"""
         SELECT
-            P.project_id,
+            G.project_id,
             G.group_id,
-            CASE
-                -- Hide area for Footprint
-                WHEN P.project_type = {Project.Type.FOOTPRINT.value} THEN 0
-                ELSE G.total_area
+            (
+                CASE
+                    -- Hide area for Footprint
+                    WHEN P.project_type = {Project.Type.FOOTPRINT.value} THEN 0
+                    ELSE G.total_area
+                END
             ) as total_task_group_area,
             G.time_spent_max_allowed
         FROM groups G

--- a/django/apps/aggregated/management/commands/update_aggregated_data.py
+++ b/django/apps/aggregated/management/commands/update_aggregated_data.py
@@ -73,11 +73,15 @@ UPDATE_PROJECT_GROUP_DATA = f"""
         G.group_id = GD.group_id;
 """
 
-TASK_GROUP_METADATA_QUERY = """
+TASK_GROUP_METADATA_QUERY = f"""
         SELECT
-            G.project_id,
+            P.project_id,
             G.group_id,
-            G.total_area as total_task_group_area,
+            CASE
+                -- Hide area for Footprint
+                WHEN P.project_type = {Project.Type.FOOTPRINT.value} THEN 0
+                ELSE G.total_area
+            ) as total_task_group_area,
             G.time_spent_max_allowed
         FROM groups G
             INNER JOIN used_task_groups UG USING (project_id, group_id)
@@ -106,9 +110,7 @@ UPDATE_USER_DATA_SQL = f"""
             FROM mapping_sessions MS
                 INNER JOIN projects P USING (project_id)
             WHERE
-                -- Skip for footprint type missions
-                P.project_type != {Project.Type.FOOTPRINT.value}
-                AND MS.start_time >= %(from_date)s
+                MS.start_time >= %(from_date)s
                 AND MS.start_time < %(until_date)s
             GROUP BY project_id, project_type, group_id -- To get unique
         ),
@@ -185,9 +187,7 @@ UPDATE_USER_GROUP_SQL = f"""
                 INNER JOIN mapping_sessions MS USING (mapping_session_id)
                 INNER JOIN projects P USING (project_id)
             WHERE
-                -- Skip for footprint type missions
-                P.project_type != {Project.Type.FOOTPRINT.value}
-                AND MS.start_time >= %(from_date)s
+                MS.start_time >= %(from_date)s
                 AND MS.start_time < %(until_date)s
             GROUP BY project_id, project_type, group_id -- To get unique
         ),

--- a/django/apps/aggregated/management/commands/update_project_groups_data.py
+++ b/django/apps/aggregated/management/commands/update_project_groups_data.py
@@ -1,0 +1,34 @@
+import time
+
+from apps.existing_database.models import Project
+from django.core.management.base import BaseCommand
+from django.db import connection, transaction
+
+from .update_aggregated_data import UPDATE_PROJECT_GROUP_DATA_USING_PROJECT_ID
+
+
+class Command(BaseCommand):
+    def handle(self, **_):
+        project_qs = Project.objects.all()
+        total_projects = project_qs.count()
+        self.stdout.write(f"Total projects: {total_projects}")
+        for index, project_id in enumerate(
+            project_qs.values_list("project_id", flat=True),
+            start=1,
+        ):
+            self.stdout.write(
+                "Running calculation for project ID "
+                f"({index}/{total_projects}): {project_id}"
+            )
+            with transaction.atomic():
+                start_time = time.time()
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        UPDATE_PROJECT_GROUP_DATA_USING_PROJECT_ID,
+                        dict(project_id=project_id),
+                    )
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"- Successfull. Runtime: {time.time() - start_time} seconds"
+                    )
+                )

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ x-django: &base_django
       DJANGO_DB_NAME: '${POSTGRES_DB}'
       DJANGO_DB_USER: '${POSTGRES_USER}'
       DJANGO_DB_PWD: '${POSTGRES_PASSWORD}'
-      DJANGO_DB_HOST: 'postgres'
+      DJANGO_DB_HOST: '${POSTGRES_HOST:-postgres}'
       DJANGO_DB_PORT: 5432
       DJANGO_STATIC_ROOT: '/assets/static/'
       DJANGO_MEDIA_ROOT: '/assets/media/'
@@ -62,7 +62,7 @@ x-mapswipe-workers: &base_mapswipe_workers
         POSTGRES_PASSWORD: '${POSTGRES_PASSWORD}'
         POSTGRES_USER: '${POSTGRES_USER}'
         POSTGRES_DB: '${POSTGRES_DB}'
-        POSTGRES_HOST: 'postgres'
+        POSTGRES_HOST: '${POSTGRES_HOST:-postgres}'
         POSTGRES_PORT: 5432
         PGDATA: '/var/lib/postgresql/mapswipe'
         IMAGE_BING_API_KEY: '${IMAGE_BING_API_KEY}'


### PR DESCRIPTION
- Address https://mapswipe.slack.com/archives/C03GP23EJPP/p1687289297561789
> [This user](https://community.mapswipe.org/user/GkT5pS3Z8Yfm7M6JEPgSH1r7WX03/?from=2023-06-13&to=2023-06-20) shared that they "left MapSwipe open" on Sunday and now his stats are showing 22 hours.

## Deployment steps
- Run project groups data calculation (Runtime: 5-6 hours for Database with 8CPU 16GB VM)
```bash
time docker-compose run --rm django ./manage.py update_project_groups_data
```
- Reset aggregated tracking point
```SQL
TRUNCATE TABLE aggregated_aggregatedtracking;
``` 
- Run aggregated data calculation (Runtime: 13-15 min for Database with 8CPU 16GB VM)
```bash
time docker-compose run --rm django ./manage.py update_aggregated_data
```
