### PR TITLE
Add optional manualUrl field to Manager Dashboard NewProject view

### DIFF
--- a/manager-dashboard/app/views/NewProject/BasicProjectInfoForm/index.tsx
+++ b/manager-dashboard/app/views/NewProject/BasicProjectInfoForm/index.tsx
@@ -187,6 +187,16 @@ function BasicProjectInfoForm(props: Props<PartialProjectFormType>) {
                         disabled={disabled || tutorialsPending}
                         nonClearable
                     />
+                    <TextInput
+                        name={'manualUrl' as const}
+                        value={value?.manualUrl}
+                        onChange={setFieldValue}
+                        error={error?.manualUrl}
+                        label="Additional information resource (URL)"
+                        hint="Provide an optional link to a resource with additional information on the project (only visible in the MapSwipe web app)"
+                        spellCheck="false"
+                        disabled={disabled}
+                    />
                     <NumberInput
                         name={'verificationNumber' as const}
                         value={value?.verificationNumber}

--- a/manager-dashboard/app/views/NewProject/utils.ts
+++ b/manager-dashboard/app/views/NewProject/utils.ts
@@ -59,6 +59,7 @@ export interface ProjectFormType {
     visibility: string;
     lookFor: string;
     tutorialId: string;
+    manualUrl: string;
     projectDetails: string;
     projectImage: File; // image
     verificationNumber: number;
@@ -229,6 +230,10 @@ export const projectFormSchema: ProjectFormSchema = {
                 required: true,
                 requiredValidation: requiredStringCondition,
                 validations: [getNoMoreThanNCharacterCondition(XS_TEXT_MAX_LENGTH)],
+            },
+            manualUrl: {
+                required: false,
+                validations: [urlCondition],
             },
             projectDetails: {
                 required: true,


### PR DESCRIPTION
The MapSwipe web application can optionally have a button on its project instructions dialog that links to an additional information resource. This PR adds a text input field to the NewProject view of the manager dashboard that allows the project creator to specify a URL that will be written to the `manualUrl` key of the processed project.

The input field is optional, and the user hint clarifies that the link to the additional resource will only be used by the web app.