### PR TITLE
fix missing usernames v2

### DIFF
--- a/mapswipe_workers/python_scripts/add_missing_usernames_in_firebase.py
+++ b/mapswipe_workers/python_scripts/add_missing_usernames_in_firebase.py
@@ -42,7 +42,7 @@ def get_all_affected_users():
     except Exception as e:
         logger.exception(e)
         logger.warning(
-            f"Could NOT update task contribution count for user in Firebase."
+            f"Could NOT get affected users from postgres."
         )
 
     return uid_list

--- a/mapswipe_workers/python_scripts/add_missing_usernames_in_firebase.py
+++ b/mapswipe_workers/python_scripts/add_missing_usernames_in_firebase.py
@@ -1,0 +1,56 @@
+from firebase_admin import auth
+
+from mapswipe_workers.auth import firebaseDB, postgresDB
+from mapswipe_workers.definitions import logger
+
+
+def update_username(uid):
+    """Set username in Firebase DB based on auth.display_name for user id."""
+    fb_db = firebaseDB()
+    try:
+        user = auth.get_user(uid)
+        username = user.display_name
+        # only set username for users with display_name
+        if not username:
+            logger.info(f"user {uid} has no display_name in firebase.")
+        else:
+            ref = fb_db.reference(f"v2/users/{user.uid}/username")
+            ref.set(username)
+            logger.info(f"updated username for user {uid}: {username}")
+    except auth.UserNotFoundError:
+        logger.info(f"could not find user {uid} in firebase to update username.")
+
+
+def get_all_affected_users():
+    """Get the user ids from all users in Firebase DB."""
+    p_con = postgresDB()
+
+    query = """
+        select 
+            user_id
+        from users u 
+        where 1=1
+            and username = ''
+            and user_id not LIKE 'osm:%'
+        ;
+    """
+
+    try:
+        data = p_con.retr_query(query)
+        uid_list = [item[0] for item in data]
+        logger.info(f"Got all {len(uid_list)} users from postgres DB.")
+    except Exception as e:
+        logger.exception(e)
+        logger.warning(
+            f"Could NOT update task contribution count for user in Firebase."
+        )
+
+    return uid_list
+
+
+if __name__ == "__main__":
+    """Get all user ids from Firebase and update username based on auth.display_name."""
+    uid_list = get_all_affected_users()
+
+    for uid in uid_list:
+        update_username(uid)

--- a/mapswipe_workers/python_scripts/update_task_contribution_count_in_firebase.py
+++ b/mapswipe_workers/python_scripts/update_task_contribution_count_in_firebase.py
@@ -50,7 +50,7 @@ def get_all_affected_users():
     except Exception as e:
         logger.exception(e)
         logger.warning(
-            f"Could NOT update task contribution count for user in Firebase."
+            f"Could NOT get affected users from posgres."
         )
 
     return uid_list


### PR DESCRIPTION
This fixes #687 

check how many users are affected:

```
select 
count(*)
from users u 
where 1=1
	and username = ''
	and user_id not LIKE 'osm:%'
	and created >= '2024-01-01'
;

```
--> 403 users

Post-merge steps:


- [ ] update tasks contribution count in firebase --> [update_task_contribution_count_in_firebase.py](https://github.com/mapswipe/python-mapswipe-workers/pull/981/files#diff-467de48abe5b5db8eb1f93e62756ef05c298a247753d510d5a480905ee9b25b3)
```
docker compose run -d mapswipe_workers_creation python python_scripts/update_task_contribution_count_in_firebase.py.
```

- [ ] set username in Firebase using https://github.com/mapswipe/python-mapswipe-workers/blob/dev/mapswipe_workers/python_scripts/add_missing_usernames_in_firebase.py

```
docker compose run -d mapswipe_workers_creation python python_scripts/add_missing_usernames_in_firebase.py
```

- [ ] update usernames in postgres --> run mapswipe_workers creation docker container
