### PR TITLE
Create Street project drafts with the Manager Dashboard

### DIFF
--- a/manager-dashboard/app/Base/configs/projectTypes.ts
+++ b/manager-dashboard/app/Base/configs/projectTypes.ts
@@ -3,6 +3,7 @@ import {
     PROJECT_TYPE_BUILD_AREA,
     PROJECT_TYPE_FOOTPRINT,
     PROJECT_TYPE_CHANGE_DETECTION,
+    PROJECT_TYPE_STREET,
     PROJECT_TYPE_COMPLETENESS,
 } from '#utils/common';
 
@@ -15,6 +16,7 @@ const mapswipeProjectTypeOptions: {
     { value: PROJECT_TYPE_BUILD_AREA, label: 'Find' },
     { value: PROJECT_TYPE_FOOTPRINT, label: 'Validate' },
     { value: PROJECT_TYPE_CHANGE_DETECTION, label: 'Compare' },
+    { value: PROJECT_TYPE_STREET, label: 'Street' },
     { value: PROJECT_TYPE_COMPLETENESS, label: 'Completeness' },
 ];
 

--- a/manager-dashboard/app/Base/styles.css
+++ b/manager-dashboard/app/Base/styles.css
@@ -122,9 +122,14 @@ p {
     --line-height-relaxed: 1.625;
     --line-height-loose: 2;
 
-
     --shadow-card: 0 2px 4px -2px var(--color-shadow);
 
     --duration-transition-medium: .2s;
+
+    --color-background-hover-light: rgba(0, 0, 0, .04);
+    --width-calendar-date: 2.4rem;
+
+    --opacity-watermark: 0.3;
+    --color-text-disabled: rgba(0, 0, 0, .3);
 
 }

--- a/manager-dashboard/app/components/Calendar/CalendarDate/index.tsx
+++ b/manager-dashboard/app/components/Calendar/CalendarDate/index.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { _cs } from '@togglecorp/fujs';
+
+import RawButton, { Props as RawButtonProps } from '../../RawButton';
+import { ymdToDateString, typedMemo } from '../../../utils/common.tsx';
+
+import styles from './styles.css';
+
+export interface Props {
+    className?: string;
+    year: number;
+    month: number;
+    date: number;
+    currentYear: number;
+    currentMonth: number;
+    activeDate?: string;
+    currentDate: number;
+    onClick?: (year: number, month: number, date: number) => void;
+    elementRef?: RawButtonProps<undefined>['elementRef'];
+    ghost?: boolean;
+}
+
+function CalendarDate(props: Props) {
+    const {
+        className,
+        year,
+        month,
+        date,
+        currentYear,
+        currentMonth,
+        currentDate,
+        onClick,
+        elementRef,
+        activeDate,
+        ghost,
+    } = props;
+
+    const handleClick = React.useCallback(() => {
+        if (onClick) {
+            onClick(year, month, date);
+        }
+    }, [year, month, date, onClick]);
+
+    const dateString = ymdToDateString(year, month, date);
+
+    return (
+        <RawButton
+            elementRef={elementRef}
+            name={date}
+            className={_cs(
+                styles.date,
+                year === currentYear
+                && month === currentMonth
+                && currentDate === date
+                && styles.today,
+                dateString === activeDate && styles.active,
+                ghost && styles.ghost,
+                className,
+            )}
+            onClick={handleClick}
+        >
+            {date}
+        </RawButton>
+
+    );
+}
+
+export default typedMemo(CalendarDate);

--- a/manager-dashboard/app/components/Calendar/CalendarDate/styles.css
+++ b/manager-dashboard/app/components/Calendar/CalendarDate/styles.css
@@ -1,0 +1,25 @@
+.date {
+    border-radius: 50%;
+    width: var(--width-calendar-date);
+    height: var(--width-calendar-date);
+
+    &.today {
+        color: var(--color-accent);
+        font-weight: var(--font-weight-bold);
+    }
+
+    &:hover {
+        background-color: var(--color-background-hover-light);
+    }
+
+    &.active {
+        background-color: var(--color-accent);
+        color: var(--color-text-on-dark);
+        pointer-events: none;
+    }
+
+    &.ghost {
+        opacity: 0.5;
+    }
+}
+

--- a/manager-dashboard/app/components/Calendar/index.tsx
+++ b/manager-dashboard/app/components/Calendar/index.tsx
@@ -1,0 +1,292 @@
+import React from 'react';
+import {
+    _cs,
+    isNotDefined,
+    isDefined,
+} from '@togglecorp/fujs';
+import {
+    IoTimeOutline,
+    IoChevronForward,
+    IoChevronBack,
+    IoCalendarOutline,
+} from 'react-icons/io5';
+
+import Button from '../Button';
+import NumberInput from '../NumberInput';
+import SelectInput from '../SelectInput';
+import useInputState from '../../hooks/useInputState';
+import { typedMemo } from '../../utils/common.tsx';
+
+import CalendarDate, { Props as CalendarDateProps } from './CalendarDate';
+
+import styles from './styles.css';
+
+const weekDayNames = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+];
+
+interface MonthName {
+    key: number;
+    label: string;
+}
+
+const monthNameList: MonthName[] = [
+    { key: 0, label: 'January' },
+    { key: 1, label: 'February' },
+    { key: 2, label: 'March' },
+    { key: 3, label: 'April' },
+    { key: 4, label: 'May' },
+    { key: 5, label: 'June' },
+    { key: 6, label: 'July' },
+    { key: 7, label: 'August' },
+    { key: 8, label: 'September' },
+    { key: 9, label: 'October' },
+    { key: 10, label: 'November' },
+    { key: 11, label: 'December' },
+];
+
+function getStartOfWeek(year: number, month: number) {
+    return new Date(year, month, 1).getDay();
+}
+
+function getNumDaysInMonth(year: number, month: number) {
+    // Setting date to 0 will switch the date to last day of previous month
+    return new Date(year, month + 1, 0).getDate();
+}
+
+interface RenderDate {
+    type: 'prevMonth' | 'currentMonth' | 'nextMonth';
+    date: number;
+}
+
+function getDates(year: number, month: number) {
+    const numDays = getNumDaysInMonth(year, month);
+    const numDayInPrevMonth = getNumDaysInMonth(year, month - 1);
+    const startOfWeek = getStartOfWeek(year, month);
+
+    const dates: RenderDate[] = [];
+
+    for (let i = 0; i < startOfWeek; i += 1) {
+        dates.push({
+            type: 'prevMonth',
+            date: numDayInPrevMonth - startOfWeek + i + 1,
+        });
+    }
+
+    for (let i = 0; i < numDays; i += 1) {
+        dates.push({
+            type: 'currentMonth',
+            date: i + 1,
+        });
+    }
+
+    // 6 rows x 7 cols
+    const remainingDates = 42 - dates.length;
+
+    for (let i = 0; i < remainingDates; i += 1) {
+        dates.push({
+            type: 'nextMonth',
+            date: i + 1,
+        });
+    }
+
+    return dates;
+}
+
+const monthKeySelector = (m: MonthName) => m.key;
+const monthLabelSelector = (m: MonthName) => m.label;
+
+type RendererOmissions = 'year' | 'month' | 'date' | 'currentYear' | 'currentMonth' | 'currentDate' | 'onClick' | 'activeDate' | 'ghost';
+export interface Props<P extends CalendarDateProps> {
+    className?: string;
+    dateRenderer?: (props: P) => React.ReactElement;
+    rendererParams?: (day: number, month: number, year: number) => Omit<P, RendererOmissions>;
+    onDateClick?: (day: number, month: number, year: number) => void;
+    monthSelectionPopupClassName?: string;
+    initialDate?: string;
+    activeDate?: string;
+}
+
+function Calendar<P extends CalendarDateProps>(props: Props<P>) {
+    const {
+        className,
+        dateRenderer: DateRenderer = CalendarDate,
+        rendererParams,
+        onDateClick,
+        monthSelectionPopupClassName,
+        initialDate,
+        activeDate,
+    } = props;
+
+    const today = new Date();
+    const current = initialDate ? new Date(initialDate) : today;
+    const currentYear = current.getFullYear();
+    const currentMonth = current.getMonth();
+
+    const [year, setYear] = useInputState<number | undefined>(currentYear);
+    const [month, setMonth] = useInputState<number>(currentMonth);
+
+    const dates = year ? getDates(year, month) : undefined;
+
+    const handleGotoCurrentButtonClick = React.useCallback(() => {
+        const date = new Date();
+        setYear(date.getFullYear());
+        setMonth(date.getMonth());
+    }, [setMonth, setYear]);
+
+    const handleNextMonthButtonClick = React.useCallback(() => {
+        if (isDefined(year)) {
+            const date = new Date(year, month + 1, 1);
+            setYear(date.getFullYear());
+            setMonth(date.getMonth());
+        }
+    }, [year, month, setMonth, setYear]);
+
+    const handlePreviousMonthButtonClick = React.useCallback(() => {
+        if (isDefined(year)) {
+            const date = new Date(year, month - 1, 1);
+            setYear(date.getFullYear());
+            setMonth(date.getMonth());
+        }
+    }, [year, month, setMonth, setYear]);
+
+    const isValidYear = React.useMemo(() => {
+        if (isNotDefined(year)) {
+            return false;
+        }
+
+        if (year < 1900 || year > 9999) {
+            return false;
+        }
+
+        return true;
+    }, [year]);
+
+    return (
+        <div className={_cs(styles.calendar, className)}>
+            <div className={styles.header}>
+                <div className={styles.info}>
+                    <div className={styles.currentYear}>
+                        <NumberInput
+                            type="number"
+                            name="calendar-year-input"
+                            onChange={setYear}
+                            value={year}
+                        />
+                    </div>
+                    <div className={styles.currentMonth}>
+                        <SelectInput
+                            name="calendar-month-input"
+                            options={monthNameList}
+                            value={month}
+                            onChange={setMonth}
+                            keySelector={monthKeySelector}
+                            labelSelector={monthLabelSelector}
+                            nonClearable
+                            optionsPopupClassName={_cs(
+                                monthSelectionPopupClassName,
+                                styles.monthSelectionPopup,
+                            )}
+                            optionsPopupContentClassName={styles.popupContent}
+                        />
+                    </div>
+                </div>
+                <div className={styles.weekDays}>
+                    {weekDayNames.map((wd) => (
+                        <div
+                            key={wd}
+                            className={styles.weekDayName}
+                        >
+                            {wd.substr(0, 2)}
+                        </div>
+                    ))}
+                </div>
+            </div>
+            {(isValidYear && isDefined(year) && dates) ? (
+                <div className={styles.dayList}>
+                    {dates.map((date) => {
+                        let newMonth = month;
+                        if (date.type === 'prevMonth') {
+                            newMonth -= 1;
+                        } else if (date.type === 'nextMonth') {
+                            newMonth += 1;
+                        }
+                        const ymd = new Date(year, newMonth, date.date);
+
+                        const defaultProps: Pick<P, RendererOmissions> = {
+                            onClick: onDateClick,
+                            year: ymd.getFullYear(),
+                            month: ymd.getMonth(),
+                            date: ymd.getDate(),
+                            currentYear: today.getFullYear(),
+                            currentMonth: today.getMonth(),
+                            currentDate: today.getDate(),
+                            activeDate,
+                            ghost: date.type === 'prevMonth' || date.type === 'nextMonth',
+                        };
+
+                        const combinedProps = {
+                            ...(rendererParams ? rendererParams(
+                                date.date, month, year,
+                            ) : undefined),
+                            ...defaultProps,
+                        } as P;
+
+                        const children = (
+                            <DateRenderer
+                                {...combinedProps}
+                            />
+                        );
+
+                        return (
+                            <div
+                                className={styles.dayContainer}
+                                key={`${date.type}-${date.date}`}
+                            >
+                                {children}
+                            </div>
+                        );
+                    })}
+                </div>
+            ) : (
+                <div className={styles.emptyDayList}>
+                    <IoCalendarOutline className={styles.icon} />
+                    Please select a valid year and month to view the dates
+                </div>
+            )}
+            <div className={styles.actions}>
+                <Button
+                    name={undefined}
+                    title="Go to current year / month"
+                    onClick={handleGotoCurrentButtonClick}
+                >
+                    <IoTimeOutline />
+                </Button>
+                <Button
+                    name={undefined}
+                    onClick={handlePreviousMonthButtonClick}
+                    title="Previous month"
+                    disabled={isNotDefined(year)}
+                >
+                    <IoChevronBack />
+                </Button>
+                <Button
+                    name={undefined}
+                    onClick={handleNextMonthButtonClick}
+                    title="Next month"
+                    disabled={isNotDefined(year)}
+                >
+                    <IoChevronForward />
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+export default typedMemo(Calendar);

--- a/manager-dashboard/app/components/Calendar/styles.css
+++ b/manager-dashboard/app/components/Calendar/styles.css
@@ -1,0 +1,93 @@
+.calendar {
+    display: flex;
+    flex-direction: column;
+
+    .header {
+        flex-shrink: 0;
+
+        .info {
+            display: flex;
+            align-items: flex-end;
+            justify-content: center;
+            padding: calc(var(--spacing-medium) - var(--spacing-small));
+
+            .current-year {
+                flex-basis: 40%;
+                padding: var(--spacing-small);
+                font-size: var(--font-size-large);
+            }
+
+            .current-month {
+                flex-basis: 60%;
+                padding: var(--spacing-small);
+            }
+        }
+
+        .week-days {
+            display: flex;
+            padding: calc(var(--spacing-medium) - var(--spacing-small));
+
+            .week-day-name {
+                display: flex;
+                align-items: center;
+                flex-basis: calc(100% / 7);
+                flex-shrink: 0;
+                justify-content: center;
+                padding: var(--spacing-small);
+                font-weight: var(--font-weight-bold);
+            }
+        }
+    }
+
+    .day-list {
+        display: flex;
+        flex-grow: 1;
+        flex-wrap: wrap;
+        padding: calc(var(--spacing-medium) - var(--spacing-small)) var(--spacing-medium);
+
+        .day-container {
+            --width: calc(100% / 7);
+            display: flex;
+            align-items: center;
+            flex-basis: var(--width);
+            justify-content: center;
+            width: var(--width);
+        }
+    }
+
+    .empty-day-list {
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+        flex-grow: 1;
+        justify-content: center;
+        padding: var(--spacing-large);
+        text-align: center;
+        color: var(--color-text);
+
+        .icon {
+            opacity: var(--opacity-watermark);
+            margin: var(--spacing-medium);
+            font-size: var(--font-size-ultra-large);
+        }
+    }
+
+    .actions {
+        display: flex;
+        flex-shrink: 0;
+        justify-content: flex-end;
+        padding: calc(var(--spacing-medium) - var(--spacing-small));
+
+        >* {
+            margin: var(--spacing-small) calc(var(--spacing-medium) - var(--spacing-small));
+        }
+    }
+}
+
+.month-selection-popup {
+    min-width: 10rem;
+
+    .popup-content {
+        width: 100%!important;
+    }
+}

--- a/manager-dashboard/app/components/DateRangeInput/index.tsx
+++ b/manager-dashboard/app/components/DateRangeInput/index.tsx
@@ -39,8 +39,8 @@ function sameMonth(foo: Date, bar: Date) {
 }
 
 export interface Value {
-    startDate: string;
-    endDate: string;
+    startDate?: string;
+    endDate?: string;
 }
 
 interface DateRendererProps extends CalendarDateProps {

--- a/manager-dashboard/app/components/DateRangeInput/index.tsx
+++ b/manager-dashboard/app/components/DateRangeInput/index.tsx
@@ -1,0 +1,420 @@
+import React, { useMemo } from 'react';
+import {
+    _cs,
+    randomString,
+    isDefined,
+    isNotDefined,
+} from '@togglecorp/fujs';
+import {
+    IoCalendarOutline,
+    IoClose,
+} from 'react-icons/io5';
+
+import useBlurEffect from '../../hooks/useBlurEffect';
+import useBooleanState from '../../hooks/useBooleanState';
+import InputContainer, { Props as InputContainerProps } from '../InputContainer';
+import RawInput from '../RawInput';
+import RawButton from '../RawButton';
+import Button from '../Button';
+import Popup from '../Popup';
+import Calendar, { Props as CalendarProps } from '../Calendar';
+import CalendarDate, { Props as CalendarDateProps } from '../Calendar/CalendarDate';
+import { ymdToDateString, dateStringToDate } from '../../utils/common.tsx';
+
+import {
+    predefinedDateRangeOptions,
+    PredefinedDateRangeKey,
+} from './predefinedDateRange';
+
+import styles from './styles.css';
+
+// FIXME: this is problematic when on end months
+function prevMonth(date: Date) {
+    const newDate = new Date(date);
+    newDate.setMonth(newDate.getMonth() - 1);
+    return newDate;
+}
+function sameMonth(foo: Date, bar: Date) {
+    return foo.getFullYear() === bar.getFullYear() && foo.getMonth() === bar.getMonth();
+}
+
+export interface Value {
+    startDate: string;
+    endDate: string;
+}
+
+interface DateRendererProps extends CalendarDateProps {
+    startDate?: string;
+    endDate?: string;
+}
+
+function DateRenderer(props: DateRendererProps) {
+    const {
+        className: dateClassName,
+        year,
+        month,
+        date,
+        startDate,
+        endDate,
+        ghost,
+        ...otherProps
+    } = props;
+
+    const start = startDate ? dateStringToDate(startDate).getTime() : undefined;
+    const end = endDate ? dateStringToDate(endDate).getTime() : undefined;
+    const current = new Date(year, month, date).getTime();
+
+    const inBetween = isDefined(start) && isDefined(end) && current > start && current < end;
+
+    const dateString = ymdToDateString(year, month, date);
+
+    const isEndDate = dateString === endDate;
+    const isStartDate = dateString === startDate;
+
+    return (
+        <CalendarDate
+            {...otherProps}
+            className={_cs(
+                styles.calendarDate,
+                dateClassName,
+                isStartDate && styles.startDate,
+                isEndDate && styles.endDate,
+                inBetween && styles.inBetween,
+                ghost && styles.ghost,
+            )}
+            year={year}
+            month={month}
+            date={date}
+            ghost={ghost}
+        />
+    );
+}
+
+type NameType = string | number | undefined;
+
+type InheritedProps = Omit<InputContainerProps, 'input'>;
+export interface Props<N extends NameType> extends InheritedProps {
+    inputElementRef?: React.RefObject<HTMLInputElement>;
+    inputClassName?: string;
+    value: Value | undefined | null;
+    name: N;
+    onChange?: (value: Value | undefined, name: N) => void;
+    placeholder?: string;
+}
+
+function DateRangeInput<N extends NameType>(props: Props<N>) {
+    const {
+        actions,
+        actionsContainerClassName,
+        className,
+        disabled,
+        error,
+        errorContainerClassName,
+        hint,
+        hintContainerClassName,
+        icons,
+        iconsContainerClassName,
+        inputSectionClassName,
+        label,
+        labelContainerClassName,
+        readOnly,
+        inputElementRef,
+        containerRef: containerRefFromProps,
+        inputSectionRef: inputSectionRefFromProps,
+        inputClassName,
+        onChange,
+        name,
+        value,
+        placeholder,
+    } = props;
+
+    const [tempDate, setTempDate] = React.useState<Partial<Value>>({
+        startDate: undefined,
+        endDate: undefined,
+    });
+    const [calendarMonthSelectionPopupClassName] = React.useState(randomString(16));
+    const createdContainerRef = React.useRef<HTMLDivElement>(null);
+    const createdInputSectionRef = React.useRef<HTMLDivElement>(null);
+    const popupRef = React.useRef<HTMLDivElement>(null);
+
+    const containerRef = containerRefFromProps ?? createdContainerRef;
+    const inputSectionRef = inputSectionRefFromProps ?? createdInputSectionRef;
+    const [
+        showCalendar,
+        setShowCalendarTrue,
+        setShowCalendarFalse,,
+        toggleShowCalendar,
+    ] = useBooleanState(false);
+
+    const hideCalendar = React.useCallback(() => {
+        setTempDate({
+            startDate: undefined,
+            endDate: undefined,
+        });
+        setShowCalendarFalse();
+    }, [setShowCalendarFalse]);
+
+    const handlePopupBlur = React.useCallback(
+        (isClickedWithin: boolean, e: MouseEvent) => {
+            // Following is to prevent the popup blur when
+            // month selection is changed in the calendar
+            const container = document.getElementsByClassName(
+                calendarMonthSelectionPopupClassName,
+            )[0];
+            const isContainerOrInsideContainer = container
+                ? container === e.target || container.contains(e.target as HTMLElement)
+                : false;
+            if (!isClickedWithin && !isContainerOrInsideContainer) {
+                hideCalendar();
+            }
+        },
+        [hideCalendar, calendarMonthSelectionPopupClassName],
+    );
+
+    useBlurEffect(
+        showCalendar,
+        handlePopupBlur,
+        popupRef,
+        inputSectionRef,
+    );
+
+    const dateRendererParams = React.useCallback(() => ({
+        startDate: tempDate.startDate ?? value?.startDate,
+        // we only set end date if user hasn't set the start date
+        // i.e. to show previously selected end date)
+        endDate: !tempDate.startDate ? value?.endDate : undefined,
+    }), [tempDate.startDate, value]);
+
+    const handleCalendarDateClick: CalendarProps<CalendarDateProps>['onDateClick'] = React.useCallback(
+        (year, month, day) => {
+            setTempDate((prevTempDate) => {
+                if (isDefined(prevTempDate.startDate)) {
+                    const lastDate = ymdToDateString(year, month, day);
+
+                    const prev = dateStringToDate(prevTempDate.startDate).getTime();
+                    const current = new Date(year, month, day).getTime();
+
+                    const startDate = prev > current ? lastDate : prevTempDate.startDate;
+                    const endDate = prev > current ? prevTempDate.startDate : lastDate;
+
+                    return {
+                        startDate,
+                        endDate,
+                    };
+                }
+
+                return {
+                    startDate: ymdToDateString(year, month, day),
+                    endDate: undefined,
+                };
+            });
+        },
+        [],
+    );
+
+    React.useEffect(() => {
+        if (isDefined(tempDate.endDate)) {
+            if (onChange) {
+                onChange(tempDate as Value, name);
+            }
+            hideCalendar();
+        }
+    }, [tempDate, hideCalendar, onChange, name]);
+
+    const handlePredefinedOptionClick = React.useCallback((optionKey: PredefinedDateRangeKey) => {
+        if (onChange) {
+            const option = predefinedDateRangeOptions.find((d) => d.key === optionKey);
+
+            if (option) {
+                const {
+                    startDate,
+                    endDate,
+                } = option.getValue();
+
+                onChange({
+                    startDate: ymdToDateString(
+                        startDate.getFullYear(),
+                        startDate.getMonth(),
+                        startDate.getDate(),
+                    ),
+                    endDate: ymdToDateString(
+                        endDate.getFullYear(),
+                        endDate.getMonth(),
+                        endDate.getDate(),
+                    ),
+                }, name);
+            }
+        }
+
+        hideCalendar();
+    }, [onChange, hideCalendar, name]);
+
+    const handleClearButtonClick = React.useCallback(() => {
+        if (onChange) {
+            onChange(undefined, name);
+        }
+    }, [onChange, name]);
+
+    const endDate = value?.endDate;
+    const endDateDate = endDate
+        ? dateStringToDate(endDate)
+        : new Date();
+
+    const startDate = value?.startDate;
+    let startDateDate = startDate
+        ? dateStringToDate(startDate)
+        : new Date();
+
+    if (sameMonth(endDateDate, startDateDate)) {
+        startDateDate = prevMonth(startDateDate);
+    }
+
+    const firstInitialDate = ymdToDateString(
+        startDateDate.getFullYear(),
+        startDateDate.getMonth(),
+        1,
+    );
+    const secondInitialDate = ymdToDateString(
+        endDateDate.getFullYear(),
+        endDateDate.getMonth(),
+        1,
+    );
+
+    const dateInputLabel = useMemo(
+        () => {
+            if (
+                isNotDefined(tempDate.startDate)
+                    && isNotDefined(value?.startDate)
+                    && isNotDefined(value?.endDate)
+            ) {
+                return undefined;
+            }
+
+            const startDateString = tempDate.startDate ?? value?.startDate;
+            const start = isDefined(startDateString)
+                ? new Date(startDateString).toLocaleDateString()
+                : '--';
+            const endDateString = value?.endDate;
+            const end = isDefined(endDateString)
+                ? new Date(endDateString).toLocaleDateString()
+                : '--';
+
+            return [
+                start,
+                end,
+            ].join(' to ');
+        },
+        [value, tempDate],
+    );
+
+    return (
+        <>
+            <InputContainer
+                containerRef={containerRef}
+                inputSectionRef={inputSectionRef}
+                actions={(
+                    <>
+                        { actions }
+                        {!readOnly && (
+                            <>
+                                {value && (
+                                    <Button
+                                        name={undefined}
+                                        onClick={handleClearButtonClick}
+                                        disabled={disabled}
+                                        title="Clear"
+                                    >
+                                        <IoClose />
+                                    </Button>
+                                )}
+                                <Button
+                                    name={undefined}
+                                    onClick={toggleShowCalendar}
+                                    disabled={disabled}
+                                    title="Show calendar"
+                                >
+                                    <IoCalendarOutline />
+                                </Button>
+                            </>
+                        )}
+                    </>
+                )}
+                actionsContainerClassName={actionsContainerClassName}
+                className={className}
+                disabled={disabled}
+                error={error}
+                errorContainerClassName={errorContainerClassName}
+                hint={hint}
+                hintContainerClassName={hintContainerClassName}
+                icons={icons}
+                iconsContainerClassName={iconsContainerClassName}
+                inputSectionClassName={inputSectionClassName}
+                inputContainerClassName={styles.inputContainer}
+                label={label}
+                labelContainerClassName={labelContainerClassName}
+                readOnly={readOnly}
+                input={(
+                    <RawInput
+                        elementRef={inputElementRef}
+                        name="date-range"
+                        value={dateInputLabel}
+                        readOnly
+                        disabled={disabled}
+                        onFocus={setShowCalendarTrue}
+                        onClick={setShowCalendarTrue}
+                        className={_cs(
+                            styles.input,
+                            !!error && styles.errored,
+                            !(tempDate.startDate || value?.startDate || value?.endDate)
+                                && styles.empty,
+                            inputClassName,
+                        )}
+                        type="text"
+                        placeholder={placeholder}
+                    />
+                )}
+            />
+            {!readOnly && showCalendar && (
+                <Popup
+                    parentRef={inputSectionRef}
+                    elementRef={popupRef}
+                    freeWidth
+                    className={styles.calendarPopup}
+                    contentClassName={styles.popupContent}
+                >
+                    <div className={styles.predefinedOptions}>
+                        {predefinedDateRangeOptions.map((opt) => (
+                            <RawButton
+                                className={styles.option}
+                                key={opt.key}
+                                name={opt.key}
+                                onClick={handlePredefinedOptionClick}
+                            >
+                                {opt.label}
+                            </RawButton>
+                        ))}
+                    </div>
+
+                    <Calendar
+                        onDateClick={handleCalendarDateClick}
+                        className={styles.calendar}
+                        monthSelectionPopupClassName={calendarMonthSelectionPopupClassName}
+                        dateRenderer={DateRenderer}
+                        rendererParams={dateRendererParams}
+                        initialDate={firstInitialDate}
+                    />
+                    <Calendar
+                        onDateClick={handleCalendarDateClick}
+                        className={styles.calendar}
+                        monthSelectionPopupClassName={calendarMonthSelectionPopupClassName}
+                        dateRenderer={DateRenderer}
+                        rendererParams={dateRendererParams}
+                        initialDate={secondInitialDate}
+                    />
+                </Popup>
+            )}
+        </>
+    );
+}
+
+export default DateRangeInput;

--- a/manager-dashboard/app/components/DateRangeInput/predefinedDateRange.ts
+++ b/manager-dashboard/app/components/DateRangeInput/predefinedDateRange.ts
@@ -1,0 +1,181 @@
+export type PredefinedDateRangeKey = 'today'
+    | 'yesterday'
+    | 'thisWeek'
+    | 'lastSevenDays'
+    | 'thisMonth'
+    | 'lastThirtyDays'
+    | 'lastThreeMonths'
+    | 'lastSixMonths'
+    | 'thisYear'
+    | 'lastYear';
+
+export interface PredefinedDateRangeOption {
+    key: PredefinedDateRangeKey;
+    label: string;
+    getValue: () => ({ startDate: Date, endDate: Date });
+}
+
+export const predefinedDateRangeOptions: PredefinedDateRangeOption[] = [
+    {
+        key: 'today',
+        label: 'Today',
+        getValue: () => ({
+            startDate: new Date(),
+            endDate: new Date(),
+        }),
+    },
+    {
+        key: 'yesterday',
+        label: 'Yesterday',
+        getValue: () => {
+            const startDate = new Date();
+            startDate.setDate(startDate.getDate() - 1);
+
+            const endDate = new Date();
+            endDate.setDate(endDate.getDate() - 1);
+
+            return {
+                startDate,
+                endDate,
+            };
+        },
+    },
+    {
+        key: 'thisWeek',
+        label: 'This week',
+        getValue: () => {
+            const startDate = new Date();
+            startDate.setDate(startDate.getDate() - startDate.getDay());
+
+            const endDate = new Date();
+            // NOTE: this will give us sunday
+            endDate.setDate(startDate.getDate() + 6);
+
+            return {
+                startDate,
+                endDate,
+            };
+        },
+    },
+    {
+        key: 'lastSevenDays',
+        label: 'Last 7 days',
+        getValue: () => {
+            const endDate = new Date();
+
+            const startDate = new Date();
+            startDate.setDate(endDate.getDate() - 7);
+
+            return {
+                startDate,
+                endDate,
+            };
+        },
+    },
+    {
+        key: 'thisMonth',
+        label: 'This month',
+        getValue: () => {
+            const startDate = new Date();
+            startDate.setDate(1);
+
+            const endDate = new Date();
+            endDate.setMonth(endDate.getMonth() + 1);
+            endDate.setDate(0);
+
+            return {
+                startDate,
+                endDate,
+            };
+        },
+    },
+    {
+        key: 'lastThirtyDays',
+        label: 'Last 30 days',
+        getValue: () => {
+            const endDate = new Date();
+
+            const startDate = new Date();
+            startDate.setDate(endDate.getDate() - 30);
+
+            return {
+                startDate,
+                endDate,
+            };
+        },
+    },
+    {
+        key: 'lastThreeMonths',
+        label: 'Last 3 months',
+        getValue: () => {
+            const startDate = new Date();
+            startDate.setMonth(startDate.getMonth() - 2);
+            startDate.setDate(1);
+
+            const endDate = new Date();
+            endDate.setMonth(endDate.getMonth() + 1);
+            endDate.setDate(0);
+
+            return {
+                startDate,
+                endDate,
+            };
+        },
+    },
+    {
+        key: 'lastSixMonths',
+        label: 'Last 6 months',
+        getValue: () => {
+            const startDate = new Date();
+            startDate.setMonth(startDate.getMonth() - 5);
+            startDate.setDate(1);
+
+            const endDate = new Date();
+            endDate.setMonth(endDate.getMonth() + 1);
+            endDate.setDate(0);
+
+            return {
+                startDate,
+                endDate,
+            };
+        },
+    },
+    {
+        key: 'thisYear',
+        label: 'This year',
+        getValue: () => {
+            const startDate = new Date();
+            startDate.setMonth(0);
+            startDate.setDate(1);
+
+            const endDate = new Date();
+            endDate.setFullYear(startDate.getFullYear() + 1);
+            endDate.setMonth(0);
+            endDate.setDate(0);
+
+            return {
+                startDate,
+                endDate,
+            };
+        },
+    },
+    {
+        key: 'lastYear',
+        label: 'Last year',
+        getValue: () => {
+            const startDate = new Date();
+            startDate.setFullYear(startDate.getFullYear() - 1);
+            startDate.setMonth(0);
+            startDate.setDate(1);
+
+            const endDate = new Date();
+            endDate.setMonth(0);
+            endDate.setDate(0);
+
+            return {
+                startDate,
+                endDate,
+            };
+        },
+    },
+];

--- a/manager-dashboard/app/components/DateRangeInput/styles.css
+++ b/manager-dashboard/app/components/DateRangeInput/styles.css
@@ -1,0 +1,85 @@
+.input-container {
+    display: flex;
+    flex-direction: row;
+
+    .input {
+        --color: var(--color-text);
+        flex-grow: 1;
+        min-width: unset;
+        color: var(--color);
+
+        &.empty {
+            --color: var(--color-input-placeholder); /* TODO */
+        }
+
+        &.errored {
+            --color: var(--color-danger);
+        }
+    }
+}
+
+.calendar-popup {
+    height: 25rem;
+
+    .popup-content {
+        display: flex;
+        max-width: unset!important;
+        max-height: unset!important;
+
+        .calendar {
+            --padding: var(--spacing-medium);
+            width: calc(var(--width-calendar-date) * 7 + 2 * var(--padding));
+            height: 100%;
+        }
+
+        .predefined-options {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            padding: calc(var(--spacing-medium) - var(--spacing-small));
+
+            .option {
+                padding: var(--spacing-small);
+                width: 100%;
+                text-align: right;
+
+                &:hover {
+                    background-color: var(--color-background-hover-light);
+                }
+            }
+        }
+    }
+}
+
+.calendar-date {
+    &.start-date {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+
+        &:not(.ghost) {
+            background-color: var(--color-accent);
+            color: var(--color-text-on-dark);
+        }
+        &.ghost {
+            background-color: var(--color-background-hover-light);
+        }
+    }
+
+    &.end-date {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+
+        &:not(.ghost) {
+            background-color: var(--color-accent);
+            color: var(--color-text-ligth);
+        }
+        &.ghost {
+            background-color: var(--color-background-hover-light);
+        }
+    }
+
+    &.in-between {
+        border-radius: 0;
+        background-color: var(--color-background-hover-light);
+    }
+}

--- a/manager-dashboard/app/utils/common.tsx
+++ b/manager-dashboard/app/utils/common.tsx
@@ -65,8 +65,9 @@ export const PROJECT_TYPE_BUILD_AREA = 1;
 export const PROJECT_TYPE_FOOTPRINT = 2;
 export const PROJECT_TYPE_CHANGE_DETECTION = 3;
 export const PROJECT_TYPE_COMPLETENESS = 4;
+export const PROJECT_TYPE_STREET = 7;
 
-export type ProjectType = 1 | 2 | 3 | 4;
+export type ProjectType = 1 | 2 | 3 | 4 | 7;
 
 export const projectTypeLabelMap: {
     [key in ProjectType]: string
@@ -75,6 +76,7 @@ export const projectTypeLabelMap: {
     [PROJECT_TYPE_FOOTPRINT]: 'Validate',
     [PROJECT_TYPE_CHANGE_DETECTION]: 'Compare',
     [PROJECT_TYPE_COMPLETENESS]: 'Completeness',
+    [PROJECT_TYPE_STREET]: 'Street',
 };
 
 export type IconKey = 'add-outline'

--- a/manager-dashboard/app/utils/common.tsx
+++ b/manager-dashboard/app/utils/common.tsx
@@ -323,3 +323,17 @@ export const formatProjectTopic = (projectTopic: string) => {
 
     return newProjectTopic;
 };
+
+export function ymdToDateString(year: number, month: number, day: number) {
+    const ys = String(year).padStart(4, '0');
+    const ms = String(month + 1).padStart(2, '0');
+    const ds = String(day).padStart(2, '0');
+
+    return `${ys}-${ms}-${ds}`;
+}
+
+export function dateStringToDate(value: string) {
+    return new Date(`${value}T00:00`);
+}
+
+export const typedMemo: (<T>(c: T) => T) = React.memo;

--- a/manager-dashboard/app/views/NewProject/index.tsx
+++ b/manager-dashboard/app/views/NewProject/index.tsx
@@ -474,7 +474,8 @@ function NewProject(props: Props) {
                     />
                 </InputSection>
                 {(
-                    value.projectType === PROJECT_TYPE_FOOTPRINT
+                    (value.projectType === PROJECT_TYPE_FOOTPRINT
+                        || value.projectType === PROJECT_TYPE_STREET)
                     && customOptions
                     && customOptions.length > 0
                 ) && (
@@ -532,7 +533,8 @@ function NewProject(props: Props) {
                 )}
                 {(value.projectType === PROJECT_TYPE_BUILD_AREA
                     || value.projectType === PROJECT_TYPE_CHANGE_DETECTION
-                    || value.projectType === PROJECT_TYPE_COMPLETENESS) && (
+                    || value.projectType === PROJECT_TYPE_COMPLETENESS
+                    || value.projectType === PROJECT_TYPE_STREET) && (
                     <InputSection
                         heading="Project AOI Geometry"
                     >

--- a/manager-dashboard/app/views/NewProject/index.tsx
+++ b/manager-dashboard/app/views/NewProject/index.tsx
@@ -318,8 +318,8 @@ function NewProject(props: Props) {
                 valuesToCopy.geometry = res.geometry;
             }
 
-            valuesToCopy.startTimestamp = valuesToCopy.dateRange?.startDate || null;
-            valuesToCopy.endTimestamp = valuesToCopy.dateRange?.endDate || null;
+            valuesToCopy.startTimestamp = valuesToCopy.dateRange?.startDate ?? null;
+            valuesToCopy.endTimestamp = valuesToCopy.dateRange?.endDate ?? null;
 
             const storage = getStorage();
             const timestamp = (new Date()).getTime();
@@ -720,11 +720,20 @@ function NewProject(props: Props) {
                     >
                         <DateRangeInput
                             name={'dateRange' as const}
-                            value={value?.dateRange} // TODO type issue
+                            value={value?.dateRange}
                             onChange={setFieldValue}
                             error={error?.dateRange}
                             label="Date range"
                             hint="Choose a date range to filter images by the date they were captured at. Empty indicates that images of all capture dates are used."
+                            disabled={submissionPending || projectTypeEmpty}
+                        />
+                        <NumberInput
+                            name={'creatorId' as const}
+                            value={value?.creatorId}
+                            onChange={setFieldValue}
+                            error={error?.creatorId}
+                            label="Image Creator ID"
+                            hint="Provide a valid Mapillary creator ID to filter for images belonging to a specific Mapillary user."
                             disabled={submissionPending || projectTypeEmpty}
                         />
                         <NumberInput

--- a/manager-dashboard/app/views/NewProject/index.tsx
+++ b/manager-dashboard/app/views/NewProject/index.tsx
@@ -418,6 +418,11 @@ function NewProject(props: Props) {
         || projectSubmissionStatus === 'projectSubmit'
     );
 
+    const tileServerVisible = value.projectType === PROJECT_TYPE_BUILD_AREA
+        || value.projectType === PROJECT_TYPE_FOOTPRINT
+        || value.projectType === PROJECT_TYPE_COMPLETENESS
+        || value.projectType === PROJECT_TYPE_CHANGE_DETECTION;
+
     const tileServerBVisible = value.projectType === PROJECT_TYPE_CHANGE_DETECTION
         || value.projectType === PROJECT_TYPE_COMPLETENESS;
 
@@ -662,17 +667,19 @@ function NewProject(props: Props) {
                     />
                 </InputSection>
 
-                <InputSection
-                    heading={tileServerBVisible ? 'Tile Server A' : 'Tile Server'}
-                >
-                    <TileServerInput
-                        name={'tileServer' as const}
-                        value={value.tileServer}
-                        error={error?.tileServer}
-                        onChange={setFieldValue}
-                        disabled={submissionPending || projectTypeEmpty}
-                    />
-                </InputSection>
+                {tileServerVisible && (
+                    <InputSection
+                        heading={tileServerBVisible ? 'Tile Server A' : 'Tile Server'}
+                    >
+                        <TileServerInput
+                            name={'tileServer' as const}
+                            value={value.tileServer}
+                            error={error?.tileServer}
+                            onChange={setFieldValue}
+                            disabled={submissionPending || projectTypeEmpty}
+                        />
+                    </InputSection>
+                )}
 
                 {tileServerBVisible && (
                     <InputSection

--- a/manager-dashboard/app/views/NewProject/index.tsx
+++ b/manager-dashboard/app/views/NewProject/index.tsx
@@ -59,6 +59,7 @@ import {
     PROJECT_TYPE_FOOTPRINT,
     PROJECT_TYPE_COMPLETENESS,
     PROJECT_TYPE_CHANGE_DETECTION,
+    PROJECT_TYPE_STREET,
     formatProjectTopic,
 } from '#utils/common';
 import { getValueFromFirebase } from '#utils/firebase';

--- a/manager-dashboard/app/views/NewProject/index.tsx
+++ b/manager-dashboard/app/views/NewProject/index.tsx
@@ -51,6 +51,7 @@ import NonFieldError from '#components/NonFieldError';
 import AnimatedSwipeIcon from '#components/AnimatedSwipeIcon';
 import ExpandableContainer from '#components/ExpandableContainer';
 import AlertBanner from '#components/AlertBanner';
+import Checkbox from '#components/Checkbox';
 import {
     valueSelector,
     labelSelector,
@@ -106,6 +107,7 @@ const defaultProjectFormValue: PartialProjectFormType = {
     // maxTasksPerUser: -1,
     inputType: PROJECT_INPUT_TYPE_UPLOAD,
     filter: FILTER_BUILDINGS,
+    isPano: false,
 };
 
 interface Props {
@@ -719,15 +721,34 @@ function NewProject(props: Props) {
                     <InputSection
                         heading="Mapillary Image Filters"
                     >
+                        <div>time range input</div>
                         <NumberInput
                             name={'organizationId' as const}
                             value={value?.organizationId}
                             onChange={setFieldValue}
                             error={error?.organizationId}
                             label="Mapillary Organization ID"
-                            hint="Provide a valid Mapillary organization ID to filter for images belonging to a specific organization."
+                            hint="Provide a valid Mapillary organization ID to filter for images belonging to a specific organization. Empty indicates that no filter is set on organization."
                             disabled={submissionPending || projectTypeEmpty}
                         />
+                        <div className={styles.inputGroup}>
+                            <NumberInput
+                                name={'samplingThreshold' as const}
+                                value={value?.samplingThreshold}
+                                onChange={setFieldValue}
+                                error={error?.samplingThreshold}
+                                label="Image Sampling Threshold"
+                                hint="What should be the minimum distance (in km) between images on the same Mapillary sequence? Empty indicates that all images on each sequence are used."
+                                disabled={submissionPending || projectTypeEmpty}
+                            />
+                            <Checkbox
+                                name={'isPano' as const}
+                                value={value?.isPano}
+                                label="Only use 360 degree panorama images."
+                                onChange={setFieldValue}
+                                disabled={submissionPending || projectTypeEmpty}
+                            />
+                        </div>
                     </InputSection>
                 )}
 

--- a/manager-dashboard/app/views/NewProject/index.tsx
+++ b/manager-dashboard/app/views/NewProject/index.tsx
@@ -50,6 +50,7 @@ import Button from '#components/Button';
 import NonFieldError from '#components/NonFieldError';
 import AnimatedSwipeIcon from '#components/AnimatedSwipeIcon';
 import ExpandableContainer from '#components/ExpandableContainer';
+import AlertBanner from '#components/AlertBanner';
 import {
     valueSelector,
     labelSelector,
@@ -465,6 +466,16 @@ function NewProject(props: Props) {
                         error={error?.projectType}
                         disabled={submissionPending || testPending}
                     />
+                    {value.projectType === PROJECT_TYPE_STREET && (
+                        <AlertBanner title="MapSwipe Web only">
+                            <div className={styles.warningContainer}>
+                                <div className={styles.warningItem}>
+                                    Projects of this type are currently
+                                    only visible in the web app.
+                                </div>
+                            </div>
+                        </AlertBanner>
+                    )}
                     <BasicProjectInfoForm
                         value={value}
                         setValue={setValue}

--- a/manager-dashboard/app/views/NewProject/index.tsx
+++ b/manager-dashboard/app/views/NewProject/index.tsx
@@ -52,6 +52,7 @@ import AnimatedSwipeIcon from '#components/AnimatedSwipeIcon';
 import ExpandableContainer from '#components/ExpandableContainer';
 import AlertBanner from '#components/AlertBanner';
 import Checkbox from '#components/Checkbox';
+import DateRangeInput from '#components/DateRangeInput';
 import {
     valueSelector,
     labelSelector,
@@ -316,6 +317,9 @@ function NewProject(props: Props) {
                 }
                 valuesToCopy.geometry = res.geometry;
             }
+
+            valuesToCopy.startTimestamp = valuesToCopy.dateRange?.startDate || null;
+            valuesToCopy.endTimestamp = valuesToCopy.dateRange?.endDate || null;
 
             const storage = getStorage();
             const timestamp = (new Date()).getTime();
@@ -711,17 +715,18 @@ function NewProject(props: Props) {
                 )}
 
                 {value.projectType === PROJECT_TYPE_STREET && (
-                    /* TODO: Add street project inputs for
-                        startTimestamp,
-                        endTimeStamp,
-                        isPano,
-                        organizationId,
-                        samplingThreshold
-                    */
                     <InputSection
                         heading="Mapillary Image Filters"
                     >
-                        <div>time range input</div>
+                        <DateRangeInput
+                            name={'dateRange' as const}
+                            value={value?.dateRange} // TODO type issue
+                            onChange={setFieldValue}
+                            error={error?.dateRange}
+                            label="Date range"
+                            hint="Choose a date range to filter images by the date they were captured at. Empty indicates that images of all capture dates are used."
+                            disabled={submissionPending || projectTypeEmpty}
+                        />
                         <NumberInput
                             name={'organizationId' as const}
                             value={value?.organizationId}

--- a/manager-dashboard/app/views/NewProject/index.tsx
+++ b/manager-dashboard/app/views/NewProject/index.tsx
@@ -707,6 +707,30 @@ function NewProject(props: Props) {
                         />
                     </InputSection>
                 )}
+
+                {value.projectType === PROJECT_TYPE_STREET && (
+                    /* TODO: Add street project inputs for
+                        startTimestamp,
+                        endTimeStamp,
+                        isPano,
+                        organizationId,
+                        samplingThreshold
+                    */
+                    <InputSection
+                        heading="Mapillary Image Filters"
+                    >
+                        <NumberInput
+                            name={'organizationId' as const}
+                            value={value?.organizationId}
+                            onChange={setFieldValue}
+                            error={error?.organizationId}
+                            label="Mapillary Organization ID"
+                            hint="Provide a valid Mapillary organization ID to filter for images belonging to a specific organization."
+                            disabled={submissionPending || projectTypeEmpty}
+                        />
+                    </InputSection>
+                )}
+
                 {error?.[nonFieldError] && (
                     <div className={styles.errorMessage}>
                         {error?.[nonFieldError]}

--- a/manager-dashboard/app/views/NewProject/styles.css
+++ b/manager-dashboard/app/views/NewProject/styles.css
@@ -75,6 +75,18 @@
         flex-shrink: 0;
         justify-content: center;
     }
+
+    .warning-container {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-extra-small);
+
+        .warning-item {
+            display: flex;
+            gap: var(--spacing-small);
+            align-items: flex-start;
+        }
+    }
 }
 
 .submission-status-modal {

--- a/manager-dashboard/app/views/NewProject/utils.ts
+++ b/manager-dashboard/app/views/NewProject/utils.ts
@@ -76,6 +76,7 @@ export interface ProjectFormType {
     tileServer: TileServer;
     tileServerB?: TileServer;
     customOptions?: CustomOptionsForProject;
+    organizationId?: number;
 }
 
 export const PROJECT_INPUT_TYPE_UPLOAD = 'aoi_file';
@@ -268,6 +269,12 @@ export const projectFormSchema: ProjectFormSchema = {
                 fields: tileServerFieldsSchema,
             },
             maxTasksPerUser: {
+                validations: [
+                    integerCondition,
+                    greaterThanCondition(0),
+                ],
+            },
+            organizationId: {
                 validations: [
                     integerCondition,
                     greaterThanCondition(0),

--- a/manager-dashboard/app/views/NewProject/utils.ts
+++ b/manager-dashboard/app/views/NewProject/utils.ts
@@ -26,6 +26,8 @@ import {
     tileServerFieldsSchema,
 } from '#components/TileServerInput';
 
+import { Value as DateRange } from '#components/DateRangeInput';
+
 import {
     getNoMoreThanNCharacterCondition,
     ProjectType,
@@ -76,6 +78,9 @@ export interface ProjectFormType {
     tileServer: TileServer;
     tileServerB?: TileServer;
     customOptions?: CustomOptionsForProject;
+    dateRange?: DateRange | null;
+    startTimestamp?: string | null;
+    endTimestamp?: string | null;
     organizationId?: number;
     isPano?: boolean;
     samplingThreshold?: number;
@@ -276,16 +281,24 @@ export const projectFormSchema: ProjectFormSchema = {
                     greaterThanCondition(0),
                 ],
             },
+            dateRange: {
+                required: false,
+            },
             organizationId: {
+                required: false,
                 validations: [
                     integerCondition,
                     greaterThanCondition(0),
                 ],
             },
             samplingThreshold: {
+                required: false,
                 validation: [
                     greaterThanCondition(0),
                 ],
+            },
+            isPano: {
+                required: false,
             },
         };
 
@@ -409,6 +422,7 @@ export const projectFormSchema: ProjectFormSchema = {
                     projectType === PROJECT_TYPE_BUILD_AREA
                     || projectType === PROJECT_TYPE_COMPLETENESS
                     || projectType === PROJECT_TYPE_CHANGE_DETECTION
+                    || projectType === PROJECT_TYPE_STREET
                     || (projectType === PROJECT_TYPE_FOOTPRINT && (
                         inputType === PROJECT_INPUT_TYPE_UPLOAD
                     ))

--- a/manager-dashboard/app/views/NewProject/utils.ts
+++ b/manager-dashboard/app/views/NewProject/utils.ts
@@ -77,6 +77,8 @@ export interface ProjectFormType {
     tileServerB?: TileServer;
     customOptions?: CustomOptionsForProject;
     organizationId?: number;
+    isPano?: boolean;
+    samplingThreshold?: number;
 }
 
 export const PROJECT_INPUT_TYPE_UPLOAD = 'aoi_file';
@@ -277,6 +279,11 @@ export const projectFormSchema: ProjectFormSchema = {
             organizationId: {
                 validations: [
                     integerCondition,
+                    greaterThanCondition(0),
+                ],
+            },
+            samplingThreshold: {
+                validation: [
                     greaterThanCondition(0),
                 ],
             },

--- a/manager-dashboard/app/views/NewProject/utils.ts
+++ b/manager-dashboard/app/views/NewProject/utils.ts
@@ -34,6 +34,7 @@ import {
     PROJECT_TYPE_FOOTPRINT,
     PROJECT_TYPE_CHANGE_DETECTION,
     PROJECT_TYPE_COMPLETENESS,
+    PROJECT_TYPE_STREET,
     IconKey,
 } from '#utils/common';
 
@@ -541,7 +542,9 @@ export function getGroupSize(projectType: ProjectType | undefined) {
         return 120;
     }
 
-    if (projectType === PROJECT_TYPE_FOOTPRINT || projectType === PROJECT_TYPE_CHANGE_DETECTION) {
+    if (projectType === PROJECT_TYPE_FOOTPRINT
+            || projectType === PROJECT_TYPE_CHANGE_DETECTION
+            || projectType === PROJECT_TYPE_STREET) {
         return 25;
     }
 

--- a/manager-dashboard/app/views/NewProject/utils.ts
+++ b/manager-dashboard/app/views/NewProject/utils.ts
@@ -82,6 +82,7 @@ export interface ProjectFormType {
     startTimestamp?: string | null;
     endTimestamp?: string | null;
     organizationId?: number;
+    creatorId?: number;
     isPano?: boolean;
     samplingThreshold?: number;
 }
@@ -283,6 +284,13 @@ export const projectFormSchema: ProjectFormSchema = {
             },
             dateRange: {
                 required: false,
+            },
+            creatorId: {
+                required: false,
+                validations: [
+                    integerCondition,
+                    greaterThanCondition(0),
+                ],
             },
             organizationId: {
                 required: false,


### PR DESCRIPTION
Adds the functionality to create new projects drafts of type "Street" with the manager dashboard.

In particular, this adds an input section for Mapillary image filter parameters to the project creation form that allows setting filters on data range, Mapillary image creator id and Mapillary organisation id, (panorama) format of the images, and a sampling threshold.

A new date range input component has been adapted from [toggle-ui](https://github.com/toggle-corp/toggle-ui/tree/develop/src/components/DateRangeInput).

This PR does not yet include new tutorial drafts for Street projects. There is a dummy street project tutorial on the MapSwipe dev instance that allows testing project draft creation.