### PR TITLE
fix(manager-dashboard): correctly set isPano for street projects

### DIFF
--- a/manager-dashboard/app/views/NewProject/index.tsx
+++ b/manager-dashboard/app/views/NewProject/index.tsx
@@ -108,7 +108,7 @@ const defaultProjectFormValue: PartialProjectFormType = {
     // maxTasksPerUser: -1,
     inputType: PROJECT_INPUT_TYPE_UPLOAD,
     filter: FILTER_BUILDINGS,
-    isPano: false,
+    panoOnly: false,
 };
 
 interface Props {
@@ -320,6 +320,7 @@ function NewProject(props: Props) {
 
             valuesToCopy.startTimestamp = valuesToCopy.dateRange?.startDate ?? null;
             valuesToCopy.endTimestamp = valuesToCopy.dateRange?.endDate ?? null;
+            valuesToCopy.isPano = valuesToCopy.panoOnly ? true : null;
 
             const storage = getStorage();
             const timestamp = (new Date()).getTime();
@@ -756,8 +757,8 @@ function NewProject(props: Props) {
                                 disabled={submissionPending || projectTypeEmpty}
                             />
                             <Checkbox
-                                name={'isPano' as const}
-                                value={value?.isPano}
+                                name={'panoOnly' as const}
+                                value={value?.panoOnly}
                                 label="Only use 360 degree panorama images."
                                 onChange={setFieldValue}
                                 disabled={submissionPending || projectTypeEmpty}

--- a/manager-dashboard/app/views/NewProject/utils.ts
+++ b/manager-dashboard/app/views/NewProject/utils.ts
@@ -83,7 +83,8 @@ export interface ProjectFormType {
     endTimestamp?: string | null;
     organizationId?: number;
     creatorId?: number;
-    isPano?: boolean;
+    panoOnly?: boolean;
+    isPano?: boolean | null;
     samplingThreshold?: number;
 }
 
@@ -304,6 +305,9 @@ export const projectFormSchema: ProjectFormSchema = {
                 validation: [
                     greaterThanCondition(0),
                 ],
+            },
+            panoOnly: {
+                required: false,
             },
             isPano: {
                 required: false,


### PR DESCRIPTION
The Mapillary image filter section on the new project form for projects of type Street has a checkbox input to determine whether Mapillary imagery should be filtered for 360° panoramic images or not.

Before this fix, leaving the box unchecked would result in adding a `isPano` field with the value `false`  to the project draft, which in return would mean that the python creation worker would filter available imagery for non-panoramic images.

With this fix, `isPano` is **not** added to the project draft if the checkbox is left unmarked, meaning that both panoramic and non-panoramic images are used, as was originally intended.