### PR TITLE
Add randomizeOrder input for new Street projects

### DIFF
--- a/manager-dashboard/app/views/NewProject/index.tsx
+++ b/manager-dashboard/app/views/NewProject/index.tsx
@@ -109,6 +109,7 @@ const defaultProjectFormValue: PartialProjectFormType = {
     inputType: PROJECT_INPUT_TYPE_UPLOAD,
     filter: FILTER_BUILDINGS,
     isPano: false,
+    randomizeOrder: false,
 };
 
 interface Props {
@@ -759,6 +760,13 @@ function NewProject(props: Props) {
                                 name={'isPano' as const}
                                 value={value?.isPano}
                                 label="Only use 360 degree panorama images."
+                                onChange={setFieldValue}
+                                disabled={submissionPending || projectTypeEmpty}
+                            />
+                            <Checkbox
+                                name={'randomizeOrder' as const}
+                                value={value?.randomizeOrder}
+                                label="Randomize the order of images in the project."
                                 onChange={setFieldValue}
                                 disabled={submissionPending || projectTypeEmpty}
                             />

--- a/manager-dashboard/app/views/NewProject/utils.ts
+++ b/manager-dashboard/app/views/NewProject/utils.ts
@@ -84,6 +84,7 @@ export interface ProjectFormType {
     organizationId?: number;
     creatorId?: number;
     isPano?: boolean;
+    randomizeOrder?: boolean;
     samplingThreshold?: number;
 }
 
@@ -306,6 +307,9 @@ export const projectFormSchema: ProjectFormSchema = {
                 ],
             },
             isPano: {
+                required: false,
+            },
+            randomizeOrder: {
                 required: false,
             },
         };


### PR DESCRIPTION
This adds an input for `randomizeOrder` to the New Project form for projects of type Street in the Manager Dashboard.

Depends on #989 