### PR TITLE
Fix Mapillary image metadata error handling

### DIFF
--- a/mapswipe_workers/mapswipe_workers/utils/process_mapillary.py
+++ b/mapswipe_workers/mapswipe_workers/utils/process_mapillary.py
@@ -16,7 +16,12 @@ from shapely import (
 from shapely.geometry import shape
 from vt2geojson import tools as vt2geojson_tools
 
-from mapswipe_workers.definitions import MAPILLARY_API_KEY, MAPILLARY_API_LINK, logger
+from mapswipe_workers.definitions import (
+    MAPILLARY_API_KEY,
+    MAPILLARY_API_LINK,
+    CustomError,
+    logger,
+)
 from mapswipe_workers.utils.spatial_sampling import spatial_sampling
 
 
@@ -239,7 +244,7 @@ def get_image_metadata(
     downloaded_metadata = coordinate_download(aoi_polygon, level, attempt_limit)
 
     if downloaded_metadata.empty or downloaded_metadata.isna().all().all():
-        raise ValueError("No Mapillary Features in the AoI.")
+        raise CustomError("No Mapillary Features in the AoI.")
 
     downloaded_metadata = downloaded_metadata[
         downloaded_metadata["geometry"].apply(lambda geom: isinstance(geom, Point))
@@ -254,14 +259,14 @@ def get_image_metadata(
         or filtered_metadata.empty
         or filtered_metadata.isna().all().all()
     ):
-        raise ValueError("No Mapillary Features in the AoI match the filter criteria.")
+        raise CustomError("No Mapillary Features in the AoI match the filter criteria.")
 
     if sampling_threshold is not None:
         filtered_metadata = spatial_sampling(filtered_metadata, sampling_threshold)
 
     total_images = len(filtered_metadata)
     if total_images > 100000:
-        raise ValueError(
+        raise CustomError(
             f"Too many Images with selected filter options for the AoI: {total_images}"
         )
 

--- a/mapswipe_workers/mapswipe_workers/utils/process_mapillary.py
+++ b/mapswipe_workers/mapswipe_workers/utils/process_mapillary.py
@@ -198,21 +198,19 @@ def filter_results(
     df = results_df.copy()
     if creator_id is not None:
         if df["creator_id"].isna().all():
-            logger.exception(
-                "No Mapillary Feature in the AoI has a 'creator_id' value."
-            )
+            logger.info("No Mapillary Feature in the AoI has a 'creator_id' value.")
             return None
         df = df[df["creator_id"] == creator_id]
 
     if is_pano is not None:
         if df["is_pano"].isna().all():
-            logger.exception("No Mapillary Feature in the AoI has a 'is_pano' value.")
+            logger.info("No Mapillary Feature in the AoI has a 'is_pano' value.")
             return None
         df = df[df["is_pano"] == is_pano]
 
     if organization_id is not None:
         if df["organization_id"].isna().all():
-            logger.exception(
+            logger.info(
                 "No Mapillary Feature in the AoI has an 'organization_id' value."
             )
             return None
@@ -220,9 +218,7 @@ def filter_results(
 
     if start_time is not None:
         if df["captured_at"].isna().all():
-            logger.exception(
-                "No Mapillary Feature in the AoI has a 'captured_at' value."
-            )
+            logger.info("No Mapillary Feature in the AoI has a 'captured_at' value.")
             return None
         df = filter_by_timerange(df, start_time, end_time)
 

--- a/mapswipe_workers/tests/unittests/test_process_mapillary.py
+++ b/mapswipe_workers/tests/unittests/test_process_mapillary.py
@@ -7,6 +7,7 @@ import pandas as pd
 from shapely import wkt
 from shapely.geometry import GeometryCollection, MultiPolygon, Point, Polygon
 
+from mapswipe_workers.definitions import CustomError
 from mapswipe_workers.utils.process_mapillary import (
     coordinate_download,
     create_tiles,
@@ -326,7 +327,7 @@ class TestTileGroupingFunctions(unittest.TestCase):
             "start_time": "1916-01-20 00:00:00",
             "end_time": "1922-01-21 23:59:59",
         }
-        with self.assertRaises(ValueError):
+        with self.assertRaises(CustomError):
             get_image_metadata(self.fixture_data, **params)
 
     @patch("mapswipe_workers.utils.process_mapillary.coordinate_download")
@@ -335,7 +336,7 @@ class TestTileGroupingFunctions(unittest.TestCase):
         df = df.drop(df.index)
         mock_coordinate_download.return_value = df
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(CustomError):
             get_image_metadata(self.fixture_data)
 
     @patch("mapswipe_workers.utils.process_mapillary.filter_results")
@@ -346,7 +347,7 @@ class TestTileGroupingFunctions(unittest.TestCase):
         mock_filter_results.return_value = pd.DataFrame({"ID": range(1, 100002)})
         mock_coordinate_download.return_value = self.fixture_df
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(CustomError):
             get_image_metadata(self.fixture_data)
 
 


### PR DESCRIPTION
get_image_metadata() raises CustomError instead of ValueError, so that errors are correctly caught in run_create_projects()