### PR TITLE
fix: set factor for time_spent_max_allowed in street projects

### DIFF
--- a/django/apps/aggregated/management/commands/update_aggregated_data.py
+++ b/django/apps/aggregated/management/commands/update_aggregated_data.py
@@ -7,6 +7,7 @@ from apps.aggregated.models import (
     AggregatedUserStatData,
 )
 from apps.existing_database.models import MappingSession, Project
+
 from django.core.management.base import BaseCommand
 from django.db import connection, models, transaction
 from django.utils import timezone
@@ -55,6 +56,7 @@ UPDATE_PROJECT_GROUP_DATA_USING_PROJECT_ID = f"""
               WHEN P.project_type = {Project.Type.CHANGE_DETECTION.value} THEN 11.2
               -- FOOTPRINT: Not calculated right now
               WHEN P.project_type = {Project.Type.FOOTPRINT.value} THEN 6.1
+              WHEN P.project_type = {Project.Type.STREET.value} THEN 65
               ELSE 1
             END
           ) * COUNT(*) as time_spent_max_allowed
@@ -110,6 +112,7 @@ UPDATE_PROJECT_GROUP_DATA_USING_TIME_RANGE = f"""
               WHEN P.project_type = {Project.Type.CHANGE_DETECTION.value} THEN 11.2
               -- FOOTPRINT: Not calculated right now
               WHEN P.project_type = {Project.Type.FOOTPRINT.value} THEN 6.1
+              WHEN P.project_type = {Project.Type.STREET.value} THEN 65
               ELSE 1
             END
           ) * COUNT(*) as time_spent_max_allowed

--- a/django/apps/aggregated/management/commands/update_aggregated_data.py
+++ b/django/apps/aggregated/management/commands/update_aggregated_data.py
@@ -7,7 +7,6 @@ from apps.aggregated.models import (
     AggregatedUserStatData,
 )
 from apps.existing_database.models import MappingSession, Project
-
 from django.core.management.base import BaseCommand
 from django.db import connection, models, transaction
 from django.utils import timezone


### PR DESCRIPTION
This sets a value of maximum 65 seconds per task to be counted into user mapping time stats for each completed task group in Street projects. The value is derived from the 95th percentile of mapping time per task in existing Street project contributions. That value is expected to decrease as soon as more contributions to Street projects are received.

Closes #1017 